### PR TITLE
fix: denom info modal

### DIFF
--- a/components/bank/components/__tests__/tokenList.test.tsx
+++ b/components/bank/components/__tests__/tokenList.test.tsx
@@ -83,10 +83,9 @@ describe('TokenList', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('Close modal')).toBeInTheDocument();
-      expect(screen.getByText('NAME')).toBeInTheDocument();
-      expect(screen.getByText('SYMBOL')).toBeInTheDocument();
-      expect(screen.getByText('DESCRIPTION')).toBeInTheDocument();
-      expect(screen.getByText('EXPONENT')).toBeInTheDocument();
+      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Ticker')).toBeInTheDocument();
+      expect(screen.getByText('Description')).toBeInTheDocument();
     });
   });
 

--- a/components/factory/modals/denomInfo.tsx
+++ b/components/factory/modals/denomInfo.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { TruncatedAddressWithCopy } from '@/components/react/addressCopy';
 import { FaExternalLinkAlt } from 'react-icons/fa';
 import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank/v1beta1/bank';
-import { useRouter } from 'next/router';
 
 export const DenomInfoModal: React.FC<{
   denom: MetadataSDKType | null;
@@ -28,50 +27,13 @@ export const DenomInfoModal: React.FC<{
         </form>
         <h3 className="text-xl font-semibold text-[#161616] dark:text-white mb-6">Denom Details</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <InfoItem label="NAME" value={denom?.name ?? 'No name available'} />
-            <InfoItem label="SYMBOL" value={denom?.symbol ?? 'No symbol available'} />
-            {denom?.description && (
-              <InfoItem
-                label="DESCRIPTION"
-                value={denom?.description ?? 'No description available'}
-              />
-            )}
-            {denom?.denom_units[1]?.exponent && (
-              <InfoItem
-                label="EXPONENT"
-                value={denom?.denom_units[1]?.exponent?.toString() ?? '0'}
-              />
-            )}
-          </div>
-          <div>
-            {denom?.denom_units?.map(
-              (
-                unit: {
-                  denom: string;
-                  aliases?: string[];
-                  exponent?: number;
-                },
-                index: number
-              ) => (
-                <div key={index} className="mb-4">
-                  <InfoItem label="DENOM" value={unit?.denom} />
-                  <InfoItem label="ALIASES" value={unit?.aliases?.join(', ') || 'No aliases'} />
-                </div>
-              )
-            )}
-          </div>
-        </div>
-        <h4 className="text-lg font-semibold text-[#161616] dark:text-white mt-6  mb-4">
-          Additional Information
-        </h4>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <InfoItem label="Name" value={denom?.name ?? 'No name available'} />
+          <InfoItem label="Symbol" value={denom?.symbol ?? 'No symbol available'} />
           <InfoItem
-            label="BASE"
-            value={denom?.base ? decodeURIComponent(denom.base) : ''}
-            isAddress={true}
+            label="Description"
+            value={denom?.description ?? 'No description available'}
+            className="col-span-2 row-span-2"
           />
-          <InfoItem label="DISPLAY" value={denom?.display ?? 'No display available'} />
         </div>
       </div>
       <form method="dialog" className="modal-backdrop" onSubmit={onClose}>
@@ -85,15 +47,17 @@ function InfoItem({
   label,
   value,
   isAddress = false,
+  className = '',
 }: {
   label: string;
   value: string;
   isAddress?: boolean;
+  className?: string;
 }) {
   return (
-    <div className="mb-4 flex flex-col">
+    <div className={`mb-4 flex flex-col ${className}`}>
       <p className="text-sm font-semibold text-[#00000099] dark:text-[#FFFFFF99] mb-2">{label}</p>
-      <div className="bg-base-300 rounded-[16px] p-4 flex-grow">
+      <div className="bg-base-300 rounded-[16px] p-4 flex-grow h-full">
         {isAddress ? (
           <div className="flex items-center">
             <TruncatedAddressWithCopy address={value} slice={8} />
@@ -104,7 +68,7 @@ function InfoItem({
               rel="noopener noreferrer"
               className="ml-2 text-primary hover:text-primary/50"
             >
-              <FaExternalLinkAlt aria-hidden="true" />{' '}
+              <FaExternalLinkAlt aria-hidden="true" />
               <span className="sr-only">External link</span>
             </a>
           </div>

--- a/components/factory/modals/denomInfo.tsx
+++ b/components/factory/modals/denomInfo.tsx
@@ -9,6 +9,10 @@ export const DenomInfoModal: React.FC<{
   isOpen?: boolean;
   onClose?: () => void;
 }> = ({ denom, modalId, isOpen, onClose }) => {
+  let nameIsAddress = false;
+  if (denom?.name.startsWith('factory/manifest1')) {
+    nameIsAddress = true;
+  }
   return (
     <dialog
       id={modalId}
@@ -27,7 +31,11 @@ export const DenomInfoModal: React.FC<{
         </form>
         <h3 className="text-xl font-semibold text-[#161616] dark:text-white mb-6">Denom Details</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <InfoItem label="Name" value={denom?.name ?? 'No name available'} />
+          <InfoItem
+            label="Name"
+            value={denom?.name ?? 'No name available'}
+            isAddress={nameIsAddress}
+          />
           <InfoItem label="Ticker" value={denom?.display.toUpperCase() ?? 'No ticker available'} />
           <InfoItem
             label="Description"
@@ -60,7 +68,7 @@ function InfoItem({
       <div className="bg-base-300 rounded-[16px] p-4 flex-grow h-full">
         {isAddress ? (
           <div className="flex items-center">
-            <TruncatedAddressWithCopy address={value} slice={8} />
+            <TruncatedAddressWithCopy address={value} slice={17} />
             <a
               href={`${process.env.NEXT_PUBLIC_TESTNET_EXPLORER_URL}/account/${value}`}
               target="_blank"

--- a/components/factory/modals/denomInfo.tsx
+++ b/components/factory/modals/denomInfo.tsx
@@ -28,7 +28,7 @@ export const DenomInfoModal: React.FC<{
         <h3 className="text-xl font-semibold text-[#161616] dark:text-white mb-6">Denom Details</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <InfoItem label="Name" value={denom?.name ?? 'No name available'} />
-          <InfoItem label="Symbol" value={denom?.symbol ?? 'No symbol available'} />
+          <InfoItem label="Ticker" value={denom?.display.toUpperCase() ?? 'No ticker available'} />
           <InfoItem
             label="Description"
             value={denom?.description ?? 'No description available'}
@@ -73,7 +73,7 @@ function InfoItem({
             </a>
           </div>
         ) : (
-          <p className="text-[#161616] dark:text-white truncate" title={value}>
+          <p className="text-[#161616] dark:text-white" title={value}>
             {value}
           </p>
         )}


### PR DESCRIPTION
This PR reworks the UI of the denom info modal to keep only the token name, ticker, and description.

Fixes #29 

![2024-11-13_10-40](https://github.com/user-attachments/assets/0f87daf1-e31c-4891-aa90-78299ab69d94)
![2024-11-13_10-40_1](https://github.com/user-attachments/assets/cde4f5a9-dbbc-443c-906f-b7b15d119938)
![2024-11-13_11-04](https://github.com/user-attachments/assets/20c13510-c3d6-48cc-b0dc-f84f5a8384ee)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified layout for the DenomInfoModal component, consolidating denomination details for easier viewing.
	- Updated labels for denomination attributes to enhance clarity (e.g., "Ticker" instead of "SYMBOL").
	- Enhanced styling flexibility with the addition of a `className` prop in the InfoItem component.
	- Adjusted address display format for improved readability.

- **Bug Fixes**
	- Removed unnecessary sections and details for a cleaner presentation of denomination information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->