### PR TITLE
fix: long account name render

### DIFF
--- a/components/wallet.tsx
+++ b/components/wallet.tsx
@@ -113,7 +113,12 @@ export const WalletSection: React.FC<WalletSectionProps> = ({ chainName }) => {
           }}
         >
           <div className="relative z-10 h-full flex flex-col  justify-between">
-            <p className="font-medium text-xl text-center mb-2">{username || 'Connected User'}</p>
+            <p
+              className="font-medium text-xl text-center mb-2 truncate"
+              title={username || 'Connected user'}
+            >
+              {username || 'Connected User'}
+            </p>
             <div className="bg-base-100 dark:bg-base-200 rounded-full py-2 px-4 text-center mb-4 flex items-center flex-row justify-between w-full ">
               <p className="text-xs  truncate flex-grow">
                 {address


### PR DESCRIPTION
Ellipsis long account name. The full account name can be displayed by hovering the mouse over the account name.

Fixes #17 

![2024-11-13_14-57](https://github.com/user-attachments/assets/2fc1e84c-fa30-41bd-bcd8-475883c3a70f)
![2024-11-13_14-58](https://github.com/user-attachments/assets/41e6890b-a23b-4f4c-ae84-eeb3c87078e0)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced username display in the WalletSection with truncation for long names and tooltip support.
	- Improved connection button behavior in the IconWallet component for clarity and efficiency.

- **Bug Fixes**
	- Maintained existing functionality for wallet connection and clipboard copy without introducing new issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->