### PR TITLE
feat: add matrix strategy to docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,12 +4,16 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    environment: 'Production - Testnet'
-
+    strategy:
+      matrix:
+        environment: [qa, testnet, mainnet]
+    environment: ${{ matrix.environment }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,9 +42,22 @@ jobs:
           echo "NEXT_PUBLIC_WEB3_CLIENT_ID=${{ secrets.NEXT_PUBLIC_WEB3_CLIENT_ID }}" >> .env
           cat .env
 
-      - name: Build and push Docker image
+      - name: Get the Git tag
+        id: get_tag
+        run: echo "GIT_TAG=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
+
+      - name: Build and push with github release tag
+        if: matrix.environment == 'mainnet' && startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: lifted/manifest-app:testnet
+          tags: lifted/manifest-app:${{ env.GIT_TAG }}
+
+      - name: Build and push Docker image
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: lifted/manifest-app:${{ matrix.environment }}


### PR DESCRIPTION
Build images for each environment (mainnet, testnet, qa) on any pushes to the main branch. Build a version-tagged mainnet image when tags are pushed. Version-tagged mainnet image will allow for finer control in the mainnet wallet. 

Workflow improvement utilizes a matrix strategy to build and tag images for each environment. 

I will add the necessary environments to the repo once the changes are reviewed. 

## Description

- Added matrix strategy for qa, testnet and mainnet environments
- Modified build and push task to build latest images tagged with environment for pushes to main
- Added build and push task for building version-tagged images for mainnet environment when tags are pushed.

## Related Issue
#68

Fixes # (issue)
#68 

## Testing

- This is the same setup as the changes in Ghostcloud - https://github.com/liftedinit/ghostcloud-frontend/pull/62 

## Breaking Changes (if applicable)

- none 

## Screenshots (if applicable)

## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Docker workflow to support multiple environments (qa, testnet, mainnet).
	- Added support for tagging Docker images based on Git tags during pushes.
  
- **Improvements**
	- Improved flexibility in the build process by dynamically selecting environments and utilizing Git tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->