### PR TITLE
Fix code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/components/groups/forms/proposals/ProposalMessages.tsx
+++ b/components/groups/forms/proposals/ProposalMessages.tsx
@@ -486,7 +486,10 @@ export default function ProposalMessages({
         if (fieldPath[i] === '__proto__' || fieldPath[i] === 'constructor') return;
         current = current[fieldPath[i]];
       }
-      if (fieldPath[fieldPath.length - 1] !== '__proto__' && fieldPath[fieldPath.length - 1] !== 'constructor') {
+      if (
+        fieldPath[fieldPath.length - 1] !== '__proto__' &&
+        fieldPath[fieldPath.length - 1] !== 'constructor'
+      ) {
         current[fieldPath[fieldPath.length - 1]] = value;
       }
 

--- a/components/groups/forms/proposals/ProposalMessages.tsx
+++ b/components/groups/forms/proposals/ProposalMessages.tsx
@@ -483,9 +483,12 @@ export default function ProposalMessages({
 
       let current = updatedMessage;
       for (let i = 0; i < fieldPath.length - 1; i++) {
+        if (fieldPath[i] === '__proto__' || fieldPath[i] === 'constructor') return;
         current = current[fieldPath[i]];
       }
-      current[fieldPath[fieldPath.length - 1]] = value;
+      if (fieldPath[fieldPath.length - 1] !== '__proto__' && fieldPath[fieldPath.length - 1] !== 'constructor') {
+        current[fieldPath[fieldPath.length - 1]] = value;
+      }
 
       dispatch({ type: 'UPDATE_MESSAGE', index, message: updatedMessage });
     };


### PR DESCRIPTION
Fixes [https://github.com/liftedinit/manifest-app/security/code-scanning/1](https://github.com/liftedinit/manifest-app/security/code-scanning/1)

To fix the problem, we need to ensure that the `fieldPath` array does not contain any properties that can lead to prototype pollution, such as `__proto__` or `constructor`. We can achieve this by adding a check to skip these properties during the assignment process.

- Modify the `handleChange` function to include a check that skips any property names that could lead to prototype pollution.
- Specifically, add a condition to skip `__proto__` and `constructor` properties when iterating through the `fieldPath` array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message handling logic to prevent unintended property modifications.
	- Implemented a validation schema for message fields, ensuring proper data entry.
	- Updated initial form values for improved user experience.

- **Bug Fixes**
	- Improved robustness of message updates and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->