### PR TITLE
feat: allow user to leave a group

### DIFF
--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -113,10 +113,12 @@ export function GroupInfo({ modalId, group, policyAddress, address, onUpdate }: 
         onSuccess: () => {
           setIsSigning(false);
           onUpdate();
+          const modal = document.getElementById(modalId) as HTMLDialogElement;
+          if (modal) modal.close();
         },
       });
     } catch (error) {
-      console.error('Error submitting proposal:', error);
+      console.error('Error leaving group:', error);
     } finally {
       setIsSigning(false);
     }
@@ -142,7 +144,7 @@ export function GroupInfo({ modalId, group, policyAddress, address, onUpdate }: 
           <div className="flex items-center space-x-4">
             <button
               aria-label={'leave-btn'}
-              className="btn btn-dropdown text-white rounded-[12px] h-[52px] w-[140px]"
+              className="btn btn-error text-white disabled:bg-red-900 rounded-[12px] h-[52px] w-[140px]"
               onClick={handleLeave}
               disabled={isSigning}
             >

--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -141,7 +141,7 @@ export function GroupInfo({ modalId, group, policyAddress, address, onUpdate }: 
           <span className="text-xl font-semibold text-secondary-content">Info</span>
           <div className="flex items-center space-x-4">
             <button
-              aria-label={'update-btn'}
+              aria-label={'leave-btn'}
               className="btn btn-dropdown text-white rounded-[12px] h-[52px] w-[140px]"
               onClick={handleLeave}
               disabled={isSigning}

--- a/pages/groups/index.tsx
+++ b/pages/groups/index.tsx
@@ -19,7 +19,7 @@ export default function Groups() {
   const groupPolicyAddresses =
     groupByMemberData?.groups?.map(group => group.policies[0].address) ?? [];
 
-  const { proposalsByPolicyAccount, isProposalsError, isProposalsLoading } =
+  const { proposalsByPolicyAccount, isProposalsError, isProposalsLoading, refetchProposals } =
     useProposalsByPolicyAccountAll(groupPolicyAddresses ?? []);
 
   const isLoading = isGroupByMemberLoading || isProposalsLoading;
@@ -82,6 +82,7 @@ export default function Groups() {
               groups={groupByMemberData ?? { groups: [] }}
               proposals={proposalsByPolicyAccount}
               isLoading={isLoading}
+              refetch={refetchGroupByMember}
             />
           ) : isError ? (
             <div className="text-center text-error">Error loading groups or proposals</div>
@@ -93,6 +94,7 @@ export default function Groups() {
                 groups={groupByMemberData ?? { groups: [] }}
                 proposals={proposalsByPolicyAccount}
                 isLoading={isLoading}
+                refetch={refetchGroupByMember}
               />
               {selectedPolicyAddress && (
                 <GroupInfo
@@ -104,7 +106,7 @@ export default function Groups() {
                     ) ?? null
                   }
                   address={address ?? ''}
-                  onUpdate={() => {}}
+                  onUpdate={refetchGroupByMember}
                 />
               )}
             </>


### PR DESCRIPTION
fixes #50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced `YourGroups` component to support data refreshing via a new `refetch` prop.
  - Introduced a `handleLeave` function in the `GroupInfo` component to facilitate group departure with transaction management.

- **Improvements**
  - Updated button functionality in the `GroupInfo` modal to disable the "Leave" button during transactions and display a loading state.
  - Improved group data handling by linking the `onUpdate` prop to trigger data refetching.

These changes streamline group management and enhance user experience within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->