### PR TITLE
fix: token factory modal states

### DIFF
--- a/components/admins/components/__tests__/validatorList.test.tsx
+++ b/components/admins/components/__tests__/validatorList.test.tsx
@@ -47,7 +47,11 @@ describe('ValidatorList', () => {
   test('clicking on a validator row opens the modal', async () => {
     renderWithProps();
     fireEvent.click(screen.getByText('Validator One'));
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    await waitFor(() => {
+      expect(screen.getByText('Validator Details')).toBeInTheDocument();
+      expect(screen.getByText('SECURITY CONTACT')).toBeInTheDocument();
+      expect(screen.getByText('OPERATOR ADDRESS')).toBeInTheDocument();
+    });
   });
 
   test('remove button works and shows the warning modal', async () => {

--- a/components/admins/components/validatorList.tsx
+++ b/components/admins/components/validatorList.tsx
@@ -28,6 +28,8 @@ export default function ValidatorList({
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedValidator, setSelectedValidator] = useState<ExtendedValidatorSDKType | null>(null);
   const [modalId, setModalId] = useState<string | null>(null);
+  const [openWarningModal, setOpenWarningModal] = useState(false);
+  const [openValidatorModal, setOpenValidatorModal] = useState(false);
 
   const [validatorToRemove, setValidatorToRemove] = useState<ExtendedValidatorSDKType | null>(null);
   const totalvp = Array.isArray(activeValidators)
@@ -44,13 +46,6 @@ export default function ValidatorList({
       }))
     : [];
 
-  useEffect(() => {
-    if (modalId) {
-      const modal = document.getElementById(modalId) as HTMLDialogElement;
-      modal?.showModal();
-    }
-  }, [modalId]);
-
   const filteredValidators = useMemo(() => {
     const validators = active ? activeValidators : pendingValidators;
     return validators.filter(validator =>
@@ -60,9 +55,7 @@ export default function ValidatorList({
 
   const handleRemove = (validator: ExtendedValidatorSDKType) => {
     setValidatorToRemove(validator);
-
-    const modal = document.getElementById(`warning-modal`) as HTMLDialogElement;
-    modal?.showModal();
+    setOpenWarningModal(true);
   };
 
   const [modalKey, setModalKey] = useState(0);
@@ -71,6 +64,7 @@ export default function ValidatorList({
     setSelectedValidator(validator);
     setModalKey(prevKey => prevKey + 1);
     setModalId(`validator-modal-${validator.operator_address}-${Date.now()}`);
+    setOpenValidatorModal(true);
   };
 
   return (
@@ -254,6 +248,8 @@ export default function ValidatorList({
         admin={admin}
         totalvp={totalvp.toString()}
         validatorVPArray={validatorVPArray}
+        openValidatorModal={openValidatorModal}
+        setOpenValidatorModal={setOpenValidatorModal}
       />
       <WarningModal
         admin={admin}
@@ -261,6 +257,8 @@ export default function ValidatorList({
         address={validatorToRemove?.operator_address || ''}
         moniker={validatorToRemove?.description.moniker || ''}
         modalId="warning-modal"
+        openWarningModal={openWarningModal}
+        setOpenWarningModal={setOpenWarningModal}
       />
     </div>
   );

--- a/components/admins/modals/validatorModal.tsx
+++ b/components/admins/modals/validatorModal.tsx
@@ -30,13 +30,28 @@ export function ValidatorDetailsModal({
   admin,
   totalvp,
   validatorVPArray,
+  openValidatorModal,
+  setOpenValidatorModal,
 }: Readonly<{
   validator: ExtendedValidatorSDKType | null;
   modalId: string;
   admin: string;
   totalvp: string;
   validatorVPArray: { vp: bigint; moniker: string }[];
+  openValidatorModal: boolean;
+  setOpenValidatorModal: (open: boolean) => void;
 }>) {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && openValidatorModal) {
+        handleClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [openValidatorModal]);
+
   const [power, setPowerInput] = useState(validator?.consensus_power?.toString() || '');
 
   const { tx, isSigning, setIsSigning } = useTx(chainName);
@@ -100,12 +115,18 @@ export function ValidatorDetailsModal({
   };
 
   const handleClose = () => {
-    const modal = document.getElementById(modalId) as HTMLDialogElement;
-    modal?.close();
+    if (setOpenValidatorModal) {
+      setOpenValidatorModal(false);
+    }
+    (document.getElementById(modalId) as HTMLDialogElement)?.close();
   };
 
   return (
-    <dialog id={modalId} className="modal">
+    <dialog
+      id={modalId}
+      className={`modal ${openValidatorModal ? 'modal-open' : ''}`}
+      onClose={handleClose}
+    >
       <Formik
         initialValues={{ power: power, totalvp, validatorVPArray }}
         validationSchema={PowerUpdateSchema}
@@ -243,7 +264,7 @@ export function ValidatorDetailsModal({
         details={validator?.description.details ?? 'No Details'}
       />
       <form method="dialog" className="modal-backdrop">
-        <button>close</button>
+        <button onClick={handleClose}>close</button>
       </form>
     </dialog>
   );

--- a/components/factory/modals/BurnModal.tsx
+++ b/components/factory/modals/BurnModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 
 import BurnForm from '@/components/factory/forms/BurnForm';
 import { useGroupsByAdmin, usePoaGetAdmin } from '@/hooks';
@@ -23,6 +23,16 @@ export default function BurnModal({
   onClose: () => void;
   onSwitchToMultiBurn: () => void;
 }) {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen]);
   const { poaAdmin, isPoaAdminLoading } = usePoaGetAdmin();
   const { groupByAdmin, isGroupByAdminLoading } = useGroupsByAdmin(
     poaAdmin ?? 'manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj'

--- a/components/factory/modals/MintModal.tsx
+++ b/components/factory/modals/MintModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank/v1beta1/bank';
 import MintForm from '@/components/factory/forms/MintForm';
 import { useGroupsByAdmin, usePoaGetAdmin } from '@/hooks';
@@ -28,6 +28,17 @@ export default function MintModal({
   admin: string;
   isPoaAdminLoading: boolean;
 }) {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen]);
+
   const [isMultiMintOpen, setIsMultiMintOpen] = useState(false);
 
   const { groupByAdmin, isGroupByAdminLoading } = useGroupsByAdmin(
@@ -56,8 +67,11 @@ export default function MintModal({
 
   return (
     <>
-      <dialog id={`mint-modal-${denom?.base}`} className={`modal ${isOpen ? 'modal-open' : ''}`}>
-        <div className="modal-box max-w-6xl mx-auto rounded-[24px] bg-[#F4F4FF] dark:bg-[#1D192D] shadow-lg">
+      <dialog
+        id={`mint-modal-${denom?.base}`}
+        className={`modal ${isOpen ? 'modal-open' : ''} z-[10000]`}
+      >
+        <div className="modal-box max-w-6xl mx-auto rounded-[24px] bg-[#F4F4FF] dark:bg-[#1D192D] z-[10000] shadow-lg">
           <form method="dialog" onSubmit={onClose}>
             <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 text-[#00000099] dark:text-[#FFFFFF99] hover:bg-[#0000000A] dark:hover:bg-[#FFFFFF1A]">
               ✕

--- a/components/factory/modals/denomInfo.tsx
+++ b/components/factory/modals/denomInfo.tsx
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { TruncatedAddressWithCopy } from '@/components/react/addressCopy';
 import { FaExternalLinkAlt } from 'react-icons/fa';
 import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank/v1beta1/bank';
 import { useEndpointStore } from '@/store/endpointStore';
 
 export const DenomInfoModal: React.FC<{
+  openDenomInfoModal: boolean;
+  setOpenDenomInfoModal: (open: boolean) => void;
   denom: MetadataSDKType | null;
   modalId: string;
-}> = ({ denom, modalId }) => {
+}> = ({ openDenomInfoModal, setOpenDenomInfoModal, denom, modalId }) => {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && openDenomInfoModal) {
+        setOpenDenomInfoModal(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [openDenomInfoModal]);
   let nameIsAddress = false;
   if (denom?.name?.startsWith('factory/manifest1')) {
     nameIsAddress = true;
@@ -16,13 +28,24 @@ export const DenomInfoModal: React.FC<{
   const { selectedEndpoint } = useEndpointStore();
   const explorerUrl = selectedEndpoint?.explorer || '';
 
+  const handleClose = () => {
+    setOpenDenomInfoModal(false);
+  };
+
   return (
-    <dialog id={modalId} className="modal" aria-labelledby="denom-info-title" aria-modal="true">
+    <dialog
+      id={modalId}
+      className={`modal ${openDenomInfoModal ? 'modal-open' : ''}`}
+      aria-labelledby="denom-info-title"
+      aria-modal="true"
+      onClose={handleClose}
+    >
       <div className="modal-box max-w-4xl mx-auto rounded-[24px] bg-[#F4F4FF] dark:bg-[#1D192D] shadow-lg">
         <form method="dialog">
           <button
             aria-label="Close modal"
             className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+            onClick={handleClose}
           >
             ✕
           </button>
@@ -76,7 +99,7 @@ export const DenomInfoModal: React.FC<{
         </div>
       </div>
       <form method="dialog" className="modal-backdrop">
-        <button>close</button>
+        <button onClick={handleClose}>close</button>
       </form>
     </dialog>
   );

--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -130,7 +130,7 @@ export function GroupInfo({ modalId, group, policyAddress, address, onUpdate }: 
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center space-x-4">
             <ProfileAvatar walletAddress={policyAddress} size={40} />
-            <h3 className="font-bold text-lg">{group.ipfsMetadata?.title}</h3>
+            <h3 className="font-bold text-lg">{group.ipfsMetadata?.title ?? 'No title'}</h3>
           </div>
           <form method="dialog">
             <button className=" absolute top-3 right-3 btn btn-sm btn-circle btn-ghost text-black dark:text-white outline-none">

--- a/components/groups/modals/memberManagementModal.tsx
+++ b/components/groups/modals/memberManagementModal.tsx
@@ -172,7 +172,7 @@ export function MemberManagementModal({
   const submitFormRef = useRef<(() => void) | null>(null);
 
   return (
-    <dialog id={modalId} className="modal z-[150]">
+    <dialog id={modalId} className="modal ">
       <div className="flex flex-col items-center w-full h-full">
         <div className="modal-box dark:bg-[#1D192D] bg-[#FFFFFF] rounded-[24px] max-w-[39rem] p-6 dark:text-white text-black">
           <form method="dialog">

--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -67,7 +67,7 @@ export const Toast: React.FC<ToastProps> = ({ toastMessage, setToastMessage }) =
     <div
       className="fixed inset-0 pointer-events-none flex items-end justify-end p-4"
       style={{
-        zIndex: 100000,
+        zIndex: 2147483647,
         position: 'fixed',
       }}
     >

--- a/pages/factory/index.tsx
+++ b/pages/factory/index.tsx
@@ -43,14 +43,6 @@ export default function Factory() {
 
   const combinedData = useMemo(() => {
     if (denoms?.denoms && metadatas?.metadatas && balances && totalSupply) {
-      const mfxBalance = balances.find(bal => bal.denom === 'umfx')?.amount || '0';
-      const mfxSupply = totalSupply.find(supply => supply.denom === 'umfx')?.amount || '0';
-      const mfxToken: ExtendedMetadataSDKType = {
-        ...MFX_TOKEN_DATA,
-        balance: mfxBalance,
-        totalSupply: mfxSupply,
-      };
-
       const otherTokens = denoms.denoms
         .filter(denom => denom !== 'umfx')
         .map((denom: string) => {
@@ -67,7 +59,7 @@ export default function Factory() {
         })
         .filter((meta): meta is ExtendedMetadataSDKType => meta !== null);
 
-      return [mfxToken, ...otherTokens];
+      return [...otherTokens];
     }
     return [];
   }, [denoms, metadatas, balances, totalSupply]);


### PR DESCRIPTION
This fixes the modal states in the token factory page. Allows for url states to be used to open specific modals for specific tokens and fixes the issues in #27. 

Youll notice the sidenav sits above the modal backdrop. There are certain changes that need to be made to accomodate proper stacking contexts which will fix #119. Depending on whats selected, all modals will need a render method change (very small just need to duplicate everywhere a modal is used)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced modal management across various components, allowing for better visibility control and user interaction.
  - Introduced keyboard accessibility for modals, enabling users to close them using the Escape key.
  - Added new state management for displaying denomination information modals.

- **Bug Fixes**
  - Improved default handling for undefined properties in the UI, ensuring a more robust user experience.

- **Chores**
  - Updated z-index values for toast notifications to ensure they appear above all other elements.

These updates enhance usability and streamline interactions within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->