### PR TITLE
fix: block explorer link

### DIFF
--- a/hooks/useTx.tsx
+++ b/hooks/useTx.tsx
@@ -4,6 +4,7 @@ import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
 import { useToast } from '@/contexts/toastContext';
 import { useState } from 'react';
 import { SigningStargateClient } from '@cosmjs/stargate';
+import { useEndpointStore } from '@/store/endpointStore';
 
 interface Msg {
   typeUrl: string;
@@ -32,6 +33,8 @@ export const useTx = (chainName: string) => {
   const { address, getSigningStargateClient, estimateFee } = useChain(chainName);
   const { setToastMessage } = useToast();
   const [isSigning, setIsSigning] = useState(false);
+  const { selectedEndpoint } = useEndpointStore();
+  const explorerUrl = selectedEndpoint?.explorer || '';
 
   const tx = async (msgs: Msg[], options: TxOptions) => {
     if (!address) {
@@ -95,7 +98,7 @@ export const useTx = (chainName: string) => {
           type: 'alert-success',
           title: 'Transaction Successful',
           description: `Transaction completed successfully`,
-          link: `https://testnet.manifest.explorers.guru/transaction/${res?.transactionHash}`,
+          link: `${explorerUrl}/transaction/${res?.transactionHash}`,
           bgColor: '#2ecc71',
         });
         return options.returnError ? { error: null } : undefined;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -7,35 +7,39 @@ import {
 } from '@heroicons/react/24/solid';
 import Head from 'next/head';
 import Link from 'next/link';
-
-const links = [
-  {
-    name: 'Docs',
-    href: 'https://github.com/liftedinit/manifest-ledger',
-    description: 'Learn how to sync nodes, query data, and use the Manifest Network.',
-    icon: BookOpenIcon,
-  },
-  {
-    name: 'Explorer',
-    href: 'https://testnet.manifest.explorers.guru/',
-    description: 'Search for transactions, wallets, and other chain data.',
-    icon: MagnifyingGlassCircleIcon,
-  },
-  {
-    name: 'FAQ',
-    href: '#',
-    description: 'The most common questions and answers about the Manifest Network.',
-    icon: BookmarkSquareIcon,
-  },
-  {
-    name: 'Blog',
-    href: '#',
-    description: 'Read our latest news and articles.',
-    icon: RssIcon,
-  },
-];
+import { useEndpointStore } from '@/store/endpointStore';
 
 export default function FourOhFour() {
+  const { selectedEndpoint } = useEndpointStore();
+  const explorerUrl = selectedEndpoint?.explorer || '';
+
+  const links = [
+    {
+      name: 'Chain Docs',
+      href: 'https://github.com/liftedinit/manifest-ledger',
+      description: 'Learn how to sync nodes, query data, and use the Manifest Network.',
+      icon: BookOpenIcon,
+    },
+    {
+      name: 'Block Explorer',
+      href: explorerUrl,
+      description: 'Search for transactions, wallets, and other chain data.',
+      icon: MagnifyingGlassCircleIcon,
+    },
+    {
+      name: 'FAQ',
+      href: '#',
+      description: 'The most common questions and answers about the Manifest Network.',
+      icon: BookmarkSquareIcon,
+    },
+    {
+      name: 'Blog',
+      href: '#',
+      description: 'Read our latest news and articles.',
+      icon: RssIcon,
+    },
+  ];
+
   return (
     <div className="">
       <Head>
@@ -72,7 +76,7 @@ export default function FourOhFour() {
             image: 'https://',
             publisher: {
               '@type': 'Organization',
-              name: 'Chandra Station',
+              name: 'The Lifted Initiative',
               logo: {
                 '@type': 'ImageObject',
                 url: 'https:///img/logo.png',


### PR DESCRIPTION
This PR fixes the block explorer link in the 404 page and in the 'Transaction Success' toast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction links to dynamically reference the selected endpoint's explorer URL.
	- Updated the 404 error page to include dynamic links for the Block Explorer based on the selected endpoint.

- **Bug Fixes**
	- Improved branding in the 404 page's structured data by updating the publisher's name.

- **Documentation**
	- Updated link names on the 404 page for clarity, changing "Docs" to "Chain Docs" and "Explorer" to "Block Explorer."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->