### PR TITLE
feat: add memo field to tx detail

### DIFF
--- a/components/bank/components/historyBox.tsx
+++ b/components/bank/components/historyBox.tsx
@@ -19,6 +19,7 @@ export interface TransactionGroup {
   tx_hash: string;
   block_number: number;
   formatted_date: string;
+  memo?: string;
   data: Transaction;
 }
 

--- a/components/bank/modals/txInfo.tsx
+++ b/components/bank/modals/txInfo.tsx
@@ -90,6 +90,9 @@ export default function TxInfoModal({ tx, modalId }: TxInfoModalProps) {
             </div>
           </div>
         </div>
+        <div>
+          <InfoItem label="MEMO" explorerUrl={explorerUrl} value={tx?.memo ?? 'N/A'} />
+        </div>
       </div>
       <form method="dialog" className="modal-backdrop">
         <button>close</button>

--- a/hooks/useQueries.ts
+++ b/hooks/useQueries.ts
@@ -939,6 +939,8 @@ const _formatMessage = (
 
 const transformTransactions = (tx: any, address: string) => {
   let messages: TransactionGroup[] = [];
+  let memo = tx.data.tx.body.memo ? { memo: tx.data.tx.body.memo } : {};
+
   for (const message of tx.data.tx.body.messages) {
     if (message['@type'] === '/cosmos.group.v1.MsgSubmitProposal') {
       for (const nestedMessage of message.messages) {
@@ -954,6 +956,7 @@ const transformTransactions = (tx: any, address: string) => {
             tx_hash: tx.id,
             block_number: parseInt(tx.data.txResponse.height),
             formatted_date: tx.data.txResponse.timestamp,
+            ...memo,
             ...formattedMessage,
           });
         }
@@ -966,6 +969,7 @@ const transformTransactions = (tx: any, address: string) => {
         tx_hash: tx.id,
         block_number: parseInt(tx.data.txResponse.height),
         formatted_date: tx.data.txResponse.timestamp,
+        ...memo,
         ...formattedMessage,
       });
     }


### PR DESCRIPTION
Fixes #140

![2024-12-09_16-31](https://github.com/user-attachments/assets/9f8bc9e3-118e-49c2-8c39-f73dfa70ab5b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an optional "MEMO" field to transaction details, enhancing the information displayed in transaction history.
	- Introduced a new section in the transaction info modal to show the "MEMO" associated with transactions.
	- Launched new hooks for improved data fetching and handling of multiple proposal tally counts.

- **Bug Fixes**
	- Improved error handling during transaction data fetching, ensuring better logging and response to issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->