### PR TITLE
feat: display network tier in nav

### DIFF
--- a/components/react/mobileNav.tsx
+++ b/components/react/mobileNav.tsx
@@ -16,6 +16,7 @@ import { WalletSection } from '../wallet';
 import { RiMenuUnfoldFill } from 'react-icons/ri';
 import { useState } from 'react';
 import { MdOutlineNetworkPing, MdContacts } from 'react-icons/md';
+import env from '@/config/env';
 
 export default function MobileNav() {
   const closeDrawer = () => {
@@ -60,7 +61,12 @@ export default function MobileNav() {
             <div className="flex flex-row justify-between items-center">
               <div className="flex flex-row gap-4 justify-between items-center">
                 <Image src={'/logo.svg'} alt="logo" width={42} height={42} />
-                <span className="text-2xl leading-tight text-balance">Alberto</span>
+                <div className="flex flex-col">
+                  <p className="text-2xl leading-tight text-balance">Alberto</p>
+                  {env.chainTier === 'mainnet' ? null : (
+                    <p className="text-md uppercase">{env.chainTier}</p>
+                  )}
+                </div>
               </div>
 
               {/* Updated Theme Toggle */}

--- a/components/react/sideNav.tsx
+++ b/components/react/sideNav.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/icons';
 
 import { MdContacts, MdOutlineNetworkPing } from 'react-icons/md';
+import env from '@/config/env';
 
 interface SideNavProps {
   isDrawerVisible: boolean;
@@ -133,7 +134,12 @@ export default function SideNav({ isDrawerVisible, setDrawerVisible }: SideNavPr
         <Link href={'/#'} passHref legacyBehavior>
           <Image src={'/logo.svg'} alt="logo" width={48} height={48} className="cursor-pointer" />
         </Link>
-        <p className="text-4xl font-bold">Alberto</p>
+        <div className="flex flex-col">
+          <p className="text-4xl font-bold">Alberto</p>
+          {env.chainTier === 'mainnet' ? null : (
+            <p className="text-md uppercase">{env.chainTier}</p>
+          )}
+        </div>
       </div>
       <ul className="flex-grow mt-8 p-1">
         <NavDrawer Icon={BankIcon} href="/bank" label="Bank" />


### PR DESCRIPTION
This PR updates the navigation to display the network tier based on the `NEXT_PUBLIC_CHAIN_TIER` environment variable. No additional information is shown if the tier is set to `mainnet`.

Note that the theming is glitchy on mobile as seen on the last screenshot. This might be related to the behavior seen in #113 

![2024-12-13_16-18](https://github.com/user-attachments/assets/c1195ced-b561-426c-a154-0df3d43eae97)
![2024-12-13_16-18_1](https://github.com/user-attachments/assets/98cd4176-2fd5-4b46-81dc-5f961db0556c)
![2024-12-13_16-19](https://github.com/user-attachments/assets/52bf1852-32bb-4f3d-8b94-e5d10cc45972)
![2024-12-13_16-19_1](https://github.com/user-attachments/assets/823f95b6-16d0-44c3-8c11-37c93605dac1)
![2024-12-13_16-20](https://github.com/user-attachments/assets/4f3a5b30-fc97-498c-a8cc-af6438605463)
![2024-12-13_16-20_1](https://github.com/user-attachments/assets/4be96381-3e4c-41a1-87e9-02f2f9b6d112)
![2024-12-13_16-20_2](https://github.com/user-attachments/assets/e9fc79d9-bb79-4020-950b-88c3c0f38114)
![2024-12-13_16-21](https://github.com/user-attachments/assets/99c58161-77a2-4621-ad92-909631e3c229)

![2024-12-13_16-17](https://github.com/user-attachments/assets/4a188bc9-8e15-4220-9035-620b5b32444d)

