### PR TITLE
fix: enable 'use my address' in group member step

### DIFF
--- a/components/groups/forms/groups/MemberInfoForm.tsx
+++ b/components/groups/forms/groups/MemberInfoForm.tsx
@@ -32,12 +32,14 @@ function MemberInfoFormFields({
   setIsContactsOpen,
   activeMemberIndex,
   setActiveMemberIndex,
+  address,
 }: Readonly<{
   dispatch: (action: Action) => void;
   isContactsOpen: boolean;
   setIsContactsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   activeMemberIndex: number | null;
   setActiveMemberIndex: React.Dispatch<React.SetStateAction<number | null>>;
+  address: string;
 }>) {
   const { values, isValid, setFieldValue } = useFormikContext<{
     members: { address: string; name: string; weight: string }[];
@@ -228,6 +230,7 @@ function MemberInfoFormFields({
         isOpen={isContactsOpen}
         setOpen={setIsContactsOpen}
         showContacts={true}
+        currentAddress={address}
         onSelect={(selectedAddress: string) => {
           if (activeMemberIndex !== null) {
             setFieldValue(`members.${activeMemberIndex}.address`, selectedAddress);
@@ -250,11 +253,13 @@ export default function MemberInfoForm({
   dispatch,
   nextStep,
   prevStep,
+  address,
 }: Readonly<{
   formData: FormData;
   dispatch: (action: Action) => void;
   nextStep: () => void;
   prevStep: () => void;
+  address: string;
 }>) {
   // Local states needed by the form fields
   const [isContactsOpen, setIsContactsOpen] = useState(false);
@@ -289,6 +294,7 @@ export default function MemberInfoForm({
                       setIsContactsOpen={setIsContactsOpen}
                       activeMemberIndex={activeMemberIndex}
                       setActiveMemberIndex={setActiveMemberIndex}
+                      address={address}
                     />
                   </div>
                 </div>

--- a/pages/groups/create.tsx
+++ b/pages/groups/create.tsx
@@ -74,6 +74,7 @@ export default function CreateGroup() {
                 dispatch={dispatch}
                 nextStep={nextStep}
                 prevStep={prevStep}
+                address={address ?? ''}
               />
             </div>
           )}


### PR DESCRIPTION
= Before
![2025-01-07_13-32](https://github.com/user-attachments/assets/93da9f97-d793-4100-b69c-0db88646837a)

= After
![2025-01-07_13-43](https://github.com/user-attachments/assets/a544f20c-d2d5-417b-a715-bff9b1cb0ef7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced member information form by adding support for address input
	- Improved group creation process with address handling

- **Bug Fixes**
	- Ensured address prop is safely passed with fallback to empty string when undefined

<!-- end of auto-generated comment: release notes by coderabbit.ai -->