### PR TITLE
Add denom prefix

### DIFF
--- a/components/factory/forms/ConfirmationForm.tsx
+++ b/components/factory/forms/ConfirmationForm.tsx
@@ -29,13 +29,19 @@ export default function ConfirmationForm({
   const effectiveAddress =
     formData.isGroup && formData.groupPolicyAddress ? formData.groupPolicyAddress : address;
 
-  const fullDenom = `factory/${effectiveAddress}/${formData.subdenom}`;
+  const getDenomInfo = (subdenom: string) => {
+    const prefixedSubdenom = subdenom.startsWith('u') ? subdenom : 'u' + subdenom;
+    const symbol = (subdenom.startsWith('u') ? subdenom.slice(1) : subdenom).toUpperCase();
+    const fullDenom = `factory/${effectiveAddress}/${prefixedSubdenom}`;
+    return { prefixedSubdenom, symbol, fullDenom };
+  };
+
+  const { prefixedSubdenom, symbol, fullDenom } = getDenomInfo(formData.subdenom);
 
   const handleConfirm = async () => {
     setIsSigning(true);
 
     const createAsGroup = async () => {
-      const symbol = formData.subdenom.slice(1).toUpperCase();
       const msg = submitProposal({
         groupPolicyAddress: formData.groupPolicyAddress || '',
         messages: [
@@ -44,7 +50,7 @@ export default function ConfirmationForm({
             value: MsgCreateDenom.encode(
               createDenom({
                 sender: formData.groupPolicyAddress || '',
-                subdenom: 'u' + formData.subdenom,
+                subdenom: prefixedSubdenom,
               }).value
             ).finish(),
           }),
@@ -62,7 +68,7 @@ export default function ConfirmationForm({
                       aliases: [symbol],
                     },
                     {
-                      denom: symbol,
+                      denom: formData.display,
                       exponent: 6,
                       aliases: [fullDenom],
                     },
@@ -99,7 +105,7 @@ export default function ConfirmationForm({
       // First, create the denom
       const createDenomMsg = createDenom({
         sender: address,
-        subdenom: 'u' + formData.subdenom,
+        subdenom: prefixedSubdenom,
       });
 
       const createDenomFee = await estimateFee(address, [createDenomMsg]);
@@ -113,7 +119,6 @@ export default function ConfirmationForm({
         return;
       }
 
-      const symbol = formData.subdenom.slice(1).toUpperCase();
       // If createDenom is successful, proceed with setDenomMetadata
       const setMetadataMsg = setDenomMetadata({
         sender: address,
@@ -126,7 +131,7 @@ export default function ConfirmationForm({
               aliases: [symbol],
             },
             {
-              denom: symbol,
+              denom: formData.display,
               exponent: 6,
               aliases: [fullDenom],
             },

--- a/components/factory/forms/ConfirmationForm.tsx
+++ b/components/factory/forms/ConfirmationForm.tsx
@@ -30,7 +30,7 @@ export default function ConfirmationForm({
     formData.isGroup && formData.groupPolicyAddress ? formData.groupPolicyAddress : address;
 
   const getDenomInfo = (subdenom: string) => {
-    const prefixedSubdenom = subdenom.startsWith('u') ? subdenom : 'u' + subdenom;
+    const prefixedSubdenom = 'u' + subdenom;
     const symbol = (subdenom.startsWith('u') ? subdenom.slice(1) : subdenom).toUpperCase();
     const fullDenom = `factory/${effectiveAddress}/${prefixedSubdenom}`;
     return { prefixedSubdenom, symbol, fullDenom };

--- a/components/factory/forms/ConfirmationForm.tsx
+++ b/components/factory/forms/ConfirmationForm.tsx
@@ -65,7 +65,7 @@ export default function ConfirmationForm({
                     {
                       denom: fullDenom,
                       exponent: 0,
-                      aliases: [symbol],
+                      aliases: [formData.display],
                     },
                     {
                       denom: formData.display,

--- a/components/factory/forms/ConfirmationForm.tsx
+++ b/components/factory/forms/ConfirmationForm.tsx
@@ -59,12 +59,12 @@ export default function ConfirmationForm({
                     {
                       denom: fullDenom,
                       exponent: 0,
-                      aliases: [symbol],
+                      aliases: [],
                     },
                     {
-                      denom: symbol,
+                      denom: formData.display,
                       exponent: 6,
-                      aliases: [fullDenom],
+                      aliases: [],
                     },
                   ],
                   base: fullDenom,
@@ -72,7 +72,7 @@ export default function ConfirmationForm({
                   name: formData.name,
                   symbol: formData.display,
                   uri: formData.uri,
-                  uriHash: formData.uriHash,
+                  uriHash: '',
                 },
               }).value
             ).finish(),
@@ -123,12 +123,12 @@ export default function ConfirmationForm({
             {
               denom: fullDenom,
               exponent: 0,
-              aliases: [symbol],
+              aliases: [],
             },
             {
-              denom: symbol,
+              denom: formData.display,
               exponent: 6,
-              aliases: [fullDenom],
+              aliases: [],
             },
           ],
           base: fullDenom,
@@ -136,7 +136,7 @@ export default function ConfirmationForm({
           name: formData.name,
           symbol: formData.display,
           uri: formData.uri,
-          uriHash: formData.uriHash,
+          uriHash: '',
         },
       });
 

--- a/components/factory/forms/ConfirmationForm.tsx
+++ b/components/factory/forms/ConfirmationForm.tsx
@@ -44,7 +44,7 @@ export default function ConfirmationForm({
             value: MsgCreateDenom.encode(
               createDenom({
                 sender: formData.groupPolicyAddress || '',
-                subdenom: formData.subdenom,
+                subdenom: 'u' + formData.subdenom,
               }).value
             ).finish(),
           }),
@@ -99,7 +99,7 @@ export default function ConfirmationForm({
       // First, create the denom
       const createDenomMsg = createDenom({
         sender: address,
-        subdenom: formData.subdenom,
+        subdenom: 'u' + formData.subdenom,
       });
 
       const createDenomFee = await estimateFee(address, [createDenomMsg]);

--- a/components/factory/forms/ConfirmationForm.tsx
+++ b/components/factory/forms/ConfirmationForm.tsx
@@ -59,12 +59,12 @@ export default function ConfirmationForm({
                     {
                       denom: fullDenom,
                       exponent: 0,
-                      aliases: [],
+                      aliases: [symbol],
                     },
                     {
-                      denom: formData.display,
+                      denom: symbol,
                       exponent: 6,
-                      aliases: [],
+                      aliases: [fullDenom],
                     },
                   ],
                   base: fullDenom,
@@ -72,7 +72,7 @@ export default function ConfirmationForm({
                   name: formData.name,
                   symbol: formData.display,
                   uri: formData.uri,
-                  uriHash: '',
+                  uriHash: formData.uriHash,
                 },
               }).value
             ).finish(),
@@ -123,12 +123,12 @@ export default function ConfirmationForm({
             {
               denom: fullDenom,
               exponent: 0,
-              aliases: [],
+              aliases: [symbol],
             },
             {
-              denom: formData.display,
+              denom: symbol,
               exponent: 6,
-              aliases: [],
+              aliases: [fullDenom],
             },
           ],
           base: fullDenom,
@@ -136,7 +136,7 @@ export default function ConfirmationForm({
           name: formData.name,
           symbol: formData.display,
           uri: formData.uri,
-          uriHash: '',
+          uriHash: formData.uriHash,
         },
       });
 

--- a/components/factory/forms/CreateDenom.tsx
+++ b/components/factory/forms/CreateDenom.tsx
@@ -21,7 +21,6 @@ export default function CreateDenom({
   const DenomSchema = Yup.object().shape({
     subdenom: Yup.string()
       .required('Subdenom is required')
-      .matches(/^[u][a-zA-Z0-9]+$/, 'Subdenom must start with the letter u')
       .min(4, 'Subdenom must be at least 4 characters')
       .max(44, 'Subdenom must not exceed 44 characters')
       .noProfanity('Profanity is not allowed')
@@ -57,8 +56,7 @@ export default function CreateDenom({
                     <TextInput
                       label="Token Sub Denom"
                       name="subdenom"
-                      placeholder="utoken"
-                      helperText="Use a subdenom starting with a prefix (e.g., 'utoken')"
+                      placeholder="token"
                       value={formData.subdenom}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         dispatch({

--- a/components/factory/forms/CreateDenom.tsx
+++ b/components/factory/forms/CreateDenom.tsx
@@ -124,6 +124,7 @@ export default function CreateDenom({
                 <button
                   className="w-[calc(50%-12px)] btn px-5 py-2.5 sm:py-3.5 btn-gradient text-white disabled:text-black"
                   onClick={() => handleSubmit()}
+                  type="submit"
                   disabled={!isValid || isSubmitting || isValidating}
                 >
                   Next: Token Metadata

--- a/components/factory/forms/CreateDenom.tsx
+++ b/components/factory/forms/CreateDenom.tsx
@@ -27,7 +27,7 @@ export default function CreateDenom({
       .simulateDenomCreation(async () => {
         setIsSimulating(true);
         try {
-          return await simulateDenomCreation(formData.subdenom);
+          return await simulateDenomCreation(`u${formData.subdenom}`);
         } finally {
           setIsSimulating(false);
         }
@@ -40,11 +40,20 @@ export default function CreateDenom({
         <Formik
           initialValues={formData}
           validationSchema={DenomSchema}
-          onSubmit={nextStep}
-          validateOnChange={true}
-          validateOnBlur={true}
+          onSubmit={async (values, { setSubmitting, setErrors }) => {
+            try {
+              await DenomSchema.validate(values, { abortEarly: false });
+              nextStep();
+            } catch (err) {
+              console.error('Validation failed:', err);
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+          validateOnChange={false}
+          validateOnBlur={false}
         >
-          {({ setFieldValue, isValid, isSubmitting, isValidating, handleSubmit }) => (
+          {({ setFieldValue, isValid, isSubmitting, isValidating, handleSubmit, setErrors }) => (
             <>
               <div className="flex items-center mx-auto w-full dark:bg-[#FFFFFF0F] bg-[#FFFFFFCC] p-6 sm:p-8 rounded-2xl shadow-lg">
                 <div className="w-full">
@@ -65,6 +74,7 @@ export default function CreateDenom({
                           value: e.target.value,
                         });
                         setFieldValue('subdenom', e.target.value);
+                        setErrors({});
                       }}
                       rightElement={
                         isSimulating && (

--- a/components/factory/forms/CreateDenom.tsx
+++ b/components/factory/forms/CreateDenom.tsx
@@ -45,7 +45,19 @@ export default function CreateDenom({
               await DenomSchema.validate(values, { abortEarly: false });
               nextStep();
             } catch (err) {
-              console.error('Validation failed:', err);
+              if (err instanceof Yup.ValidationError) {
+                const errors = err.inner.reduce(
+                  (acc: Record<string, string>, error) => ({
+                    ...acc,
+                    [error.path as string]: error.message,
+                  }),
+                  {}
+                );
+                setErrors(errors);
+              } else {
+                console.error('Unexpected error:', err);
+                setErrors({ subdenom: 'An unexpected error occurred' });
+              }
             } finally {
               setSubmitting(false);
             }

--- a/components/factory/forms/TokenDetailsForm.tsx
+++ b/components/factory/forms/TokenDetailsForm.tsx
@@ -43,17 +43,17 @@ export default function TokenDetails({
   const effectiveAddress =
     formData.isGroup && formData.groupPolicyAddress ? formData.groupPolicyAddress : address;
 
-  const fullDenom = `factory/${effectiveAddress}/${formData.subdenom}`;
-
+  const fullDenom = `factory/${effectiveAddress}/u${formData.subdenom}`;
+  console.log(formData);
   // Automatically set denom units
   React.useEffect(() => {
     const denomUnits = [
       { denom: fullDenom, exponent: 0, aliases: [] },
-      { denom: formData.subdenom.slice(1), exponent: 6, aliases: [] },
+      { denom: formData.display, exponent: 6, aliases: [] },
     ];
     updateField('denomUnits', denomUnits);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formData.subdenom, address]);
+  }, [formData.subdenom, formData.display, address]);
 
   return (
     <section>
@@ -78,7 +78,7 @@ export default function TokenDetails({
                         label="Subdenom"
                         name="subdenom"
                         disabled={true}
-                        value={formData.subdenom}
+                        value={`u${formData.subdenom}`}
                         aria-label="Token subdenom"
                       />
                       <TextInput

--- a/components/factory/forms/__tests__/CreateDenom.test.tsx
+++ b/components/factory/forms/__tests__/CreateDenom.test.tsx
@@ -32,7 +32,7 @@ describe('CreateDenom Component', () => {
 
   test('updates subdenom input correctly', async () => {
     renderWithChainProvider(<CreateDenom {...mockProps} />);
-    const subdenomInput = screen.getByPlaceholderText('utoken');
+    const subdenomInput = screen.getByPlaceholderText('token');
     fireEvent.change(subdenomInput, { target: { value: 'utest' } });
     await waitFor(() => {
       expect(mockProps.dispatch).toHaveBeenCalledWith({
@@ -43,30 +43,10 @@ describe('CreateDenom Component', () => {
     });
   });
 
-  test('shows validation error for invalid subdenom', async () => {
-    renderWithChainProvider(<CreateDenom {...mockProps} />);
-    const subdenomInput = screen.getByPlaceholderText('utoken');
-    fireEvent.change(subdenomInput, { target: { value: 'invalid' } });
-    fireEvent.blur(subdenomInput);
-    await waitFor(() => {
-      expect(screen.getByText('Subdenom must start with the letter u')).toBeInTheDocument();
-    });
-  });
-
-  test('confirm button is disabled when inputs are invalid', async () => {
-    renderWithChainProvider(<CreateDenom {...mockProps} />);
-    const confirmButton = screen.getByText('Next: Token Metadata');
-    const subdenomInput = screen.getByPlaceholderText('utoken');
-    fireEvent.change(subdenomInput, { target: { value: 'invalid' } });
-    await waitFor(() => {
-      expect(confirmButton).toBeDisabled();
-    });
-  });
-
   test('confirm button is enabled when inputs are valid', async () => {
     renderWithChainProvider(<CreateDenom {...mockProps} />);
     const confirmButton = screen.getByText('Next: Token Metadata');
-    const subdenomInput = screen.getByPlaceholderText('utoken');
+    const subdenomInput = screen.getByPlaceholderText('token');
     fireEvent.change(subdenomInput, { target: { value: 'utest' } });
     fireEvent.blur(subdenomInput);
     await waitFor(() => {


### PR DESCRIPTION
- **chore: add 'u' to subdenom programatically**
- **fix: fix factory creation metadata issue**
- **fix: revert metadata issues**

This PR:
- adds the denom prefix 'u' programtically. 
- fixes metadata issues
- makes the denom creation simulation smoother



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Modified denom creation process to automatically prefix `subdenom` with 'u'.
	- Updated form validation for subdenom input, broadening acceptable input range.
	- Enhanced user input experience by simplifying form input placeholder and removing helper text.
	- Improved handling of denom details by adjusting the construction of `fullDenom` and `denomUnits`.

- **Bug Fixes**
	- Improved form submission button behavior by adding `type="submit"`.
	- Streamlined test cases by removing unnecessary validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->