### PR TITLE
feat: collapsable address/tx in auth signer

### DIFF
--- a/components/icons/ArrowRightIcon.tsx
+++ b/components/icons/ArrowRightIcon.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { SVGProps } from 'react';
 
-export const ArrowRightIcon: React.FC<SVGProps<SVGSVGElement>> = props => (
+interface ArrowRightIconProps extends SVGProps<SVGSVGElement> {
+  size?: number;
+}
+
+export const ArrowRightIcon: React.FC<ArrowRightIconProps> = ({ size, ...props }) => (
   <svg
-    width="24"
-    height="24"
+    width={size || 24}
+    height={size || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/components/messageSyntax.tsx
+++ b/components/messageSyntax.tsx
@@ -31,3 +31,23 @@ export function messageSyntax(fieldsToShow: string[], message: MessageType, them
     </SyntaxHighlighter>
   );
 }
+
+export function objectSyntax(object: Record<string, any>, theme: string) {
+  const prettyPrintJSON = (obj: Record<string, any>): string => {
+    return JSON.stringify(obj, null, 2);
+  };
+
+  return (
+    <SyntaxHighlighter
+      language="json"
+      style={theme === 'dark' ? oneDark : oneLight}
+      customStyle={{
+        backgroundColor: 'transparent',
+        padding: '1rem',
+        borderRadius: '0.5rem',
+      }}
+    >
+      {prettyPrintJSON(object)}
+    </SyntaxHighlighter>
+  );
+}


### PR DESCRIPTION
This pr:
- makes the address & tx info on the auth signer modal collapsable
- adds json syntax highlighting to the auth signer tx info section
- decodes the base64 value of every tx in the auth signer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced icon component with customizable size
	- Added new function for syntax highlighting JSON objects
	- Improved authentication signer modal with:
		- Dynamic message decoding
		- Expandable address and transaction info
		- Enhanced user interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->