### PR TITLE
fix: only show successful tx in history

### DIFF
--- a/components/bank/components/historyBox.tsx
+++ b/components/bank/components/historyBox.tsx
@@ -1,12 +1,10 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { TruncatedAddressWithCopy } from '@/components/react/addressCopy';
 import TxInfoModal from '../modals/txInfo';
-import { shiftDigits, truncateString } from '@/utils';
+import { shiftDigits } from '@/utils';
 import { BurnIcon, DenomImage, formatDenom, MintIcon } from '@/components';
 import { HistoryTxType, useTokenFactoryDenomsMetadata } from '@/hooks';
 import { ReceiveIcon, SendIcon } from '@/components/icons';
-
-import useIsMobile from '@/hooks/useIsMobile';
 
 interface Transaction {
   tx_type: HistoryTxType;

--- a/hooks/useQueries.ts
+++ b/hooks/useQueries.ts
@@ -784,6 +784,11 @@ const transformTransactions = (tx: any, address: string) => {
   let messages: TransactionGroup[] = [];
   let memo = tx.data.tx.body.memo ? { memo: tx.data.tx.body.memo } : {};
 
+  // Skip the transaction if it's not successful
+  if (tx.data.txResponse.code && tx.data.txResponse.code !== 0) {
+    return messages;
+  }
+
   for (const message of tx.data.tx.body.messages) {
     if (message['@type'] === '/cosmos.group.v1.MsgSubmitProposal') {
       for (const nestedMessage of message.messages) {
@@ -863,7 +868,6 @@ export const useGetFilteredTxAndSuccessfulProposals = (
       const transactions = dataResponse.data
         .flatMap((tx: any) => transformTransactions(tx, address))
         .filter((tx: any) => tx !== null)
-        // Add secondary JS sort
         .sort((a: any, b: any) => {
           // Sort by timestamp descending (newest first)
           const dateComparison =

--- a/pages/bank.tsx
+++ b/pages/bank.tsx
@@ -206,24 +206,21 @@ export default function Bank() {
                         searchTerm={searchTerm}
                       />
                     ))}
-                  {activeTab === 'history' &&
-                    (sendTxs.length === 0 ? (
-                      <NoActivityFound />
-                    ) : (
-                      <HistoryBox
-                        currentPage={currentPage}
-                        setCurrentPage={setCurrentPage}
-                        address={address ?? ''}
-                        isLoading={isLoading}
-                        sendTxs={sendTxs}
-                        totalPages={totalPages}
-                        txLoading={txLoading}
-                        isError={isError}
-                        refetch={refetchHistory}
-                        skeletonGroupCount={skeletonGroupCount}
-                        skeletonTxCount={skeletonTxCount}
-                      />
-                    ))}
+                  {activeTab === 'history' && (
+                    <HistoryBox
+                      currentPage={currentPage}
+                      setCurrentPage={setCurrentPage}
+                      address={address ?? ''}
+                      isLoading={isLoading}
+                      sendTxs={sendTxs}
+                      totalPages={totalPages}
+                      txLoading={txLoading}
+                      isError={isError}
+                      refetch={refetchHistory}
+                      skeletonGroupCount={skeletonGroupCount}
+                      skeletonTxCount={skeletonTxCount}
+                    />
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Fixes #188 

![2025-01-08_11-42](https://github.com/user-attachments/assets/286218a1-f8a7-442d-b4cb-56790f41e098)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed unused imports in the `HistoryBox` component
	- Updated transaction processing logic to skip failed transactions
	- Modified transaction sorting to order by timestamp instead of block height

<!-- end of auto-generated comment: release notes by coderabbit.ai -->