### PR TITLE
fix: asset list cleanup

### DIFF
--- a/components/bank/components/__tests__/tokenList.test.tsx
+++ b/components/bank/components/__tests__/tokenList.test.tsx
@@ -71,7 +71,14 @@ describe('TokenList', () => {
         pageSize={1}
       />
     );
-    expect(screen.getByText('utoken1')).toBeInTheDocument();
+    const token1Row = screen.getByLabelText('utoken1');
+    expect(token1Row).toBeInTheDocument();
+
+    const ticker = within(token1Row).getAllByText('TOKEN 1');
+    expect(ticker).toHaveLength(2);
+
+    const balance = within(token1Row).getByText('0.001');
+    expect(balance).toBeInTheDocument();
   });
 
   test('displays loading skeleton when isLoading is true', () => {
@@ -114,8 +121,10 @@ describe('TokenList', () => {
         searchTerm={'Token 1'}
       />
     );
-    expect(screen.getByText('Token 1')).toBeInTheDocument();
-    expect(screen.queryByText('Token 2')).not.toBeInTheDocument();
+    const token1Row = screen.getByLabelText('utoken1');
+    const token2Row = screen.queryByLabelText('utoken2');
+    expect(token1Row).toBeInTheDocument();
+    expect(token2Row).not.toBeInTheDocument();
   });
 
   test('opens modal with correct denomination information', async () => {
@@ -154,20 +163,5 @@ describe('TokenList', () => {
     );
     expect(screen.getByText('0.001')).toBeInTheDocument();
     expect(screen.getByText('0.002')).toBeInTheDocument();
-  });
-
-  test('displays correct base denomination for each token', () => {
-    renderWithChainProvider(
-      <TokenList
-        balances={mockBalances}
-        isLoading={false}
-        refetchBalances={jest.fn()}
-        refetchHistory={jest.fn()}
-        address={''}
-        pageSize={2}
-      />
-    );
-    expect(screen.getByText('utoken1')).toBeInTheDocument();
-    expect(screen.getByText('utoken2')).toBeInTheDocument();
   });
 });

--- a/components/bank/components/tokenList.tsx
+++ b/components/bank/components/tokenList.tsx
@@ -107,14 +107,9 @@ export function TokenList(props: Readonly<TokenListProps>) {
                   <div className="  flex items-center justify-center">
                     <DenomImage denom={balance.metadata} />
                   </div>
-                  <div>
-                    <p className="font-semibold text-[#161616] dark:text-white">
-                      {truncateString(balance.metadata?.display ?? '', 12)}
-                    </p>
-                    <p className="text-sm text-[#00000099] dark:text-[#FFFFFF99]">
-                      {balance.metadata?.denom_units[0]?.denom.split('/').pop()}
-                    </p>
-                  </div>
+                  <p className="font-semibold text-[#161616] dark:text-white">
+                    {truncateString(balance.metadata?.display ?? '', 12).toUpperCase()}
+                  </p>
                 </div>
                 <div className="text-center hidden sm:block md:block lg:hidden xl:block">
                   <p className="font-semibold text-[#161616] dark:text-white">


### PR DESCRIPTION
Use uppercase ticker and remove subdenom display.

![2025-01-10_10-43](https://github.com/user-attachments/assets/4c10407b-570c-4cb8-8e54-176eab8d7ba5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated token display in the token list to show token names in uppercase.
	- Simplified token information rendering by removing denomination details.
	- Streamlined component's visual presentation without changing core functionality.

- **Tests**
	- Enhanced token identification in tests by using accessible labels.
	- Updated assertions to verify the presence of token tickers and balances within the correct context.
	- Removed tests for base denomination display, focusing on more relevant validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->