### PR TITLE
Remove the link to a 404 in the denom info window

### DIFF
--- a/components/factory/modals/denomInfo.tsx
+++ b/components/factory/modals/denomInfo.tsx
@@ -122,16 +122,6 @@ function InfoItem({
         {isAddress ? (
           <div className="flex items-center">
             <TruncatedAddressWithCopy address={value} slice={17} />
-            <a
-              href={`${explorerUrl}/account/${value}`}
-              target="_blank"
-              aria-label={`View ${value} on block explorer (opens in new tab)`}
-              rel="noopener noreferrer"
-              className="ml-2 text-primary hover:text-primary/50"
-            >
-              <FaExternalLinkAlt aria-hidden="true" />
-              <span className="sr-only">External link</span>
-            </a>
           </div>
         ) : (
           <p className="text-[#161616] dark:text-white" title={value}>


### PR DESCRIPTION
Factory tokens don't seem to be supported by the blockchain explorer, so this will never lead to an actual page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Removed Features**
	- Removed external link functionality for address information in the modal
	- Eliminated ability to navigate to block explorer from address details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->