### PR TITLE
fix: remove subdenom display check

### DIFF
--- a/components/factory/forms/TokenDetailsForm.tsx
+++ b/components/factory/forms/TokenDetailsForm.tsx
@@ -18,13 +18,7 @@ export default function TokenDetails({
   address: string;
 }>) {
   const TokenDetailsSchema = Yup.object().shape({
-    display: Yup.string()
-      .required('Display is required')
-      .noProfanity()
-      .test('display-contains-subdenom', 'Display must contain subdenom', function (value) {
-        const subdenom = this.parent.subdenom;
-        return !subdenom || value.toLowerCase().includes(subdenom.slice(1).toLowerCase());
-      }),
+    display: Yup.string().required('Display is required').noProfanity(),
     description: Yup.string()
       .required('Description is required')
       .min(10, 'Description must be at least 10 characters long')

--- a/components/factory/modals/updateDenomMetadata.tsx
+++ b/components/factory/modals/updateDenomMetadata.tsx
@@ -15,13 +15,7 @@ import { useProposalsByPolicyAccount } from '@/hooks/useQueries';
 
 const TokenDetailsSchema = (context: { subdenom: string }) =>
   Yup.object().shape({
-    display: Yup.string()
-      .required('Display is required')
-      .noProfanity()
-      .test('display-contains-subdenom', 'Display must contain subdenom', function (value) {
-        const subdenom = context.subdenom;
-        return !subdenom || value.toLowerCase().includes(subdenom.slice(1).toLowerCase());
-      }),
+    display: Yup.string().required('Display is required').noProfanity(),
     name: Yup.string().required('Name is required').noProfanity(),
     description: Yup.string()
       .required('Description is required')


### PR DESCRIPTION
Fixes #220 

![2025-01-28_14-14](https://github.com/user-attachments/assets/af815821-ca0b-4a83-a087-5cd54a2659da)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified validation logic for token display field
	- Removed unnecessary subdenom check in token details form validation

The changes focus on streamlining the validation process for token metadata, making the form validation more straightforward while maintaining core validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->