### PR TITLE
fix pending validator icon

### DIFF
--- a/components/admins/modals/validatorModal.tsx
+++ b/components/admins/modals/validatorModal.tsx
@@ -165,11 +165,13 @@ export function ValidatorDetailsModal({
               <div className="flex flex-col justify-start items-start gap-4">
                 <span className="text-sm text-gray-500 dark:text-gray-400">VALIDATOR</span>
                 <div className="flex flex-row justify-start items-center gap-4">
-                  {validator?.logo_url !== '' ? (
+                  {validator?.logo_url && (
                     <img className="h-16 w-16 rounded-full" src={validator.logo_url} alt="" />
-                  ) : (
+                  )}
+                  {!validator?.logo_url && (
                     <ProfileAvatar walletAddress={validator?.operator_address} size={64} />
                   )}
+
                   <span className="text-2xl font-bold text-black dark:text-white">
                     {validator?.description.moniker}
                   </span>


### PR DESCRIPTION
This PR fixes an issue where pending validators who do not have a logo_uri do not properly display the stock generated avatar. #223

If you'd like to test this pr locally without submitting a validator creation request add 

```ts
const pendingValsMock = [
    {
      operator_address: 'manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj',
      consensus_pubkey: undefined,
      jailed: false,
      status: BondStatus.BOND_STATUS_BONDED,

      tokens: '1000000',
      delegator_shares: '1000000',
      description: {
        moniker: 'Test Validator',
        identity: 'test123',
        website: 'https://test.com',
        details: 'test details',
        security_contact: 'test@test.com',
      },
      unbonding_height: BigInt(0),
      unbonding_time: new Date(),
      commission: {
        rate: '0.1',
        max_rate: '0.2',
        update_time: new Date(),
        max_change_rate: '0.01',
        commission_rates: {
          rate: '0.1',
          max_rate: '0.2',
          max_change_rate: '0.01',
        },
      },
      min_self_delegation: '1000000',
      unbonding_on_hold_ref_count: BigInt(0),
      unbonding_ids: [],
    },
  ];

```

In the pending data for the `ValidatorList`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logo display by automatically showing a fallback avatar when no custom image is available.
	- Ensured that the current input value is properly used during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->