### PR TITLE
Refetch transactions and metadatas at an interval after the last refetch

### DIFF
--- a/components/bank/components/historyBox.tsx
+++ b/components/bank/components/historyBox.tsx
@@ -6,8 +6,9 @@ import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank
 import { useTokenFactoryDenomsMetadata } from '@/hooks';
 import TxInfoModal from '../modals/txInfo';
 
-/// Interval to refresh the history box transaction and metadata.
-const HISTORY_BOX_REFRESH_INTERVAL = 3000;
+// Interval to refresh the history box transaction and metadata.
+// This is used as a delay between successful queries.
+const HISTORY_BOX_REFRESH_INTERVAL = 1000;
 
 export interface TransactionGroup {
   tx_hash: string;
@@ -39,7 +40,7 @@ export function HistoryBox({
   totalPages: number;
   txLoading: boolean;
   isError: boolean;
-  refetch: () => Promise<void> | void;
+  refetch: () => Promise<any>;
   skeletonGroupCount: number;
   skeletonTxCount: number;
   isGroup?: boolean;
@@ -72,7 +73,7 @@ export function HistoryBox({
       done = true;
       clearTimeout(timer);
     };
-  }, [metadatas, refetchMetadatas]);
+  }, [refetchMetadatas]);
 
   function formatDateShort(dateString: string): string {
     const date = new Date(dateString);

--- a/components/bank/components/historyBox.tsx
+++ b/components/bank/components/historyBox.tsx
@@ -52,7 +52,7 @@ export function HistoryBox({
   const isLoading = initialLoading || txLoading || isMetadatasLoading;
 
   useIntervalDebounceEffect(
-    () => Promise.all([refetch(), refetchMetadatas()]).then(() => {}),
+    () => Promise.all([refetch(), refetchMetadatas()]),
     HISTORY_BOX_REFRESH_INTERVAL,
     [refetch, refetchMetadatas]
   );

--- a/components/bank/components/historyBox.tsx
+++ b/components/bank/components/historyBox.tsx
@@ -73,7 +73,7 @@ export function HistoryBox({
       done = true;
       clearTimeout(timer);
     };
-  }, [refetchMetadatas]);
+  }, [refetch, refetchMetadatas]);
 
   function formatDateShort(dateString: string): string {
     const date = new Date(dateString);

--- a/components/bank/components/historyBox.tsx
+++ b/components/bank/components/historyBox.tsx
@@ -41,7 +41,7 @@ export function HistoryBox({
   totalPages: number;
   txLoading: boolean;
   isError: boolean;
-  refetch: () => Promise<any>;
+  refetch: () => Promise<unknown>;
   skeletonGroupCount: number;
   skeletonTxCount: number;
   isGroup?: boolean;

--- a/components/groups/components/groupControls.tsx
+++ b/components/groups/components/groupControls.tsx
@@ -42,7 +42,7 @@ type GroupControlsProps = {
   denomLoading: boolean;
   isDenomError: boolean;
   refetchBalances: () => void;
-  refetchHistory: () => void;
+  refetchHistory: () => Promise<any>;
   refetchDenoms: () => void;
   refetchGroupInfo: () => void;
   pageSize: number;

--- a/components/groups/components/groupControls.tsx
+++ b/components/groups/components/groupControls.tsx
@@ -42,7 +42,7 @@ type GroupControlsProps = {
   denomLoading: boolean;
   isDenomError: boolean;
   refetchBalances: () => void;
-  refetchHistory: () => Promise<any>;
+  refetchHistory: () => Promise<unknown>;
   refetchDenoms: () => void;
   refetchGroupInfo: () => void;
   pageSize: number;

--- a/hooks/useDebounceEffect.ts
+++ b/hooks/useDebounceEffect.ts
@@ -18,7 +18,6 @@ export const useIntervalDebounceEffect = (
 
     async function inner() {
       if (done) return;
-      console.log(2);
 
       try {
         await callback();
@@ -31,11 +30,9 @@ export const useIntervalDebounceEffect = (
       }
     }
 
-    console.log(3, delay);
     latestTimer = setTimeout(inner, delay);
 
     return () => {
-      console.log(4);
       done = true;
       clearTimeout(latestTimer);
     };

--- a/hooks/useDebounceEffect.ts
+++ b/hooks/useDebounceEffect.ts
@@ -22,6 +22,8 @@ export const useIntervalDebounceEffect = (
 
       try {
         await callback();
+      } catch (error) {
+        console.error('Error during refetch:', error);
       } finally {
         if (!done) {
           latestTimer = setTimeout(inner, delay);

--- a/hooks/useDebounceEffect.ts
+++ b/hooks/useDebounceEffect.ts
@@ -1,0 +1,42 @@
+import { DependencyList, useEffect } from 'react';
+
+/**
+ * Create a debounce effect that will call the callback function after the delay has passed,
+ * on an interval.
+ * @param callback The function to call
+ * @param delay The delay in milliseconds
+ * @param dependencies The dependencies to watch for changes
+ */
+export const useIntervalDebounceEffect = (
+  callback: () => Promise<void>,
+  delay: number,
+  dependencies?: DependencyList
+) => {
+  useEffect(() => {
+    let done = false;
+    let latestTimer: Timer | undefined;
+
+    async function inner() {
+      if (done) return;
+      console.log(2);
+
+      try {
+        await callback();
+      } finally {
+        if (!done) {
+          latestTimer = setTimeout(inner, delay);
+        }
+      }
+    }
+
+    console.log(3, delay);
+    latestTimer = setTimeout(inner, delay);
+
+    return () => {
+      console.log(4);
+      done = true;
+      clearTimeout(latestTimer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+};

--- a/hooks/useDebounceEffect.ts
+++ b/hooks/useDebounceEffect.ts
@@ -8,7 +8,7 @@ import { DependencyList, useEffect } from 'react';
  * @param dependencies The dependencies to watch for changes
  */
 export const useIntervalDebounceEffect = (
-  callback: () => Promise<void>,
+  callback: () => Promise<unknown>,
   delay: number,
   dependencies?: DependencyList
 ) => {


### PR DESCRIPTION
Fixes #239

This is lacking tests as I'm not sure how to test refetch without having to wait 3 seconds between mocks.

I tested it (and false tested too) manually and it works wonderfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented an auto-refresh mechanism that updates the transaction history and related metadata periodically, ensuring the display remains current.

- **Refactor**
  - Updated method signatures to support asynchronous operations, enhancing the handling of data fetching in the components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->