### PR TITLE
Remove 1Password from all our input texts

### DIFF
--- a/components/react/inputs/TextInput.tsx
+++ b/components/react/inputs/TextInput.tsx
@@ -2,5 +2,5 @@ import React from 'react';
 import { BaseInput } from './BaseInput';
 
 export const TextInput: React.FC<React.ComponentProps<typeof BaseInput>> = props => (
-  <BaseInput type="text" {...props} />
+  <BaseInput type="text" data-1p-ignore {...props} />
 );


### PR DESCRIPTION
There might be a place where we want 1Password to allow for showing the autofill dialog, but any place I found that was showing it it was more annoying.

For example, it shows over the Contact button in the Address input, because it wants to fill it with my street address.

Example:

<img width="522" alt="CleanShot 2025-02-07 at 10 31 48@2x" src="https://github.com/user-attachments/assets/a3414abf-e460-43c2-ac47-db82b8de46b5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the text input component with a minor behind-the-scenes update to optimize its internal processing without altering any visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->