### PR TITLE
fix: only use 1 source wallet | memoize components that call balances

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install
+      - name: Build
+        run: bun run build

--- a/components/bank/components/__tests__/sendBox.test.tsx
+++ b/components/bank/components/__tests__/sendBox.test.tsx
@@ -63,7 +63,6 @@ describe('SendBox', () => {
 
     // Verify cross-chain elements are present
     await waitFor(() => {
-      expect(screen.getByLabelText('from-chain-selector')).toBeInTheDocument();
       expect(screen.getByLabelText('to-chain-selector')).toBeInTheDocument();
     });
   });
@@ -73,7 +72,6 @@ describe('SendBox', () => {
     fireEvent.click(screen.getByLabelText('cross-chain-transfer-tab'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('from-chain-selector')).toBeInTheDocument();
       expect(screen.getByLabelText('to-chain-selector')).toBeInTheDocument();
     });
   });

--- a/components/bank/components/sendBox.tsx
+++ b/components/bank/components/sendBox.tsx
@@ -4,6 +4,7 @@ import IbcSendForm from '../forms/ibcSendForm';
 import env from '@/config/env';
 import { CombinedBalanceInfo } from '@/utils/types';
 import { ChainContext } from '@cosmos-kit/core';
+import React from 'react';
 
 export interface IbcChain {
   id: string;
@@ -13,7 +14,7 @@ export interface IbcChain {
   chainID: string;
 }
 
-export default function SendBox({
+export default React.memo(function SendBox({
   address,
   balances,
   isBalancesLoading,
@@ -23,11 +24,6 @@ export default function SendBox({
   isGroup,
   admin,
   refetchProposals,
-  osmosisBalances,
-  isOsmosisBalancesLoading,
-  refetchOsmosisBalances,
-  resolveOsmosisRefetch,
-  chains,
 }: {
   address: string;
   balances: CombinedBalanceInfo[];
@@ -38,11 +34,6 @@ export default function SendBox({
   selectedDenom?: string;
   isGroup?: boolean;
   admin?: string;
-  osmosisBalances: CombinedBalanceInfo[];
-  isOsmosisBalancesLoading: boolean;
-  refetchOsmosisBalances: () => void;
-  resolveOsmosisRefetch: () => void;
-  chains: Record<string, ChainContext>;
 }) {
   const ibcChains = useMemo<IbcChain[]>(
     () => [
@@ -73,6 +64,8 @@ export default function SendBox({
   const [activeTab, setActiveTab] = useState<'send' | 'cross-chain'>('send');
   const [selectedFromChain, setSelectedFromChain] = useState<IbcChain>(ibcChains[0]);
   const [selectedToChain, setSelectedToChain] = useState<IbcChain>(ibcChains[1]);
+
+  const memoizedBalances = useMemo(() => balances, [balances]);
 
   useEffect(() => {
     if (selectedFromChain && selectedToChain && selectedFromChain.id === selectedToChain.id) {
@@ -132,25 +125,20 @@ export default function SendBox({
                 setSelectedToChain={setSelectedToChain}
                 address={address}
                 destinationChain={selectedToChain}
-                balances={balances}
+                balances={memoizedBalances}
                 isBalancesLoading={isBalancesLoading}
                 refetchBalances={refetchBalances}
                 refetchHistory={refetchHistory}
                 selectedDenom={selectedDenom}
-                osmosisBalances={osmosisBalances}
                 isGroup={isGroup}
                 admin={admin}
                 refetchProposals={refetchProposals}
-                isOsmosisBalancesLoading={isOsmosisBalancesLoading}
-                refetchOsmosisBalances={refetchOsmosisBalances}
-                resolveOsmosisRefetch={resolveOsmosisRefetch}
                 availableToChains={getAvailableToChains}
-                chains={chains}
               />
             ) : (
               <SendForm
                 address={address}
-                balances={balances}
+                balances={memoizedBalances}
                 isBalancesLoading={isBalancesLoading}
                 refetchBalances={refetchBalances}
                 refetchHistory={refetchHistory}
@@ -165,4 +153,4 @@ export default function SendBox({
       </div>
     </div>
   );
-}
+});

--- a/components/bank/components/sendBox.tsx
+++ b/components/bank/components/sendBox.tsx
@@ -40,14 +40,14 @@ export default React.memo(function SendBox({
       {
         id: env.chain,
         name: 'Manifest',
-        icon: 'logo.svg',
+        icon: '/logo.svg',
         prefix: 'manifest',
         chainID: env.chainId,
       },
       {
         id: env.osmosisChain,
         name: 'Osmosis',
-        icon: 'osmosis.svg',
+        icon: '/osmosis.svg',
         prefix: 'osmo',
         chainID: env.osmosisChainId,
       },

--- a/components/bank/components/tokenList.tsx
+++ b/components/bank/components/tokenList.tsx
@@ -17,14 +17,9 @@ interface TokenListProps {
   admin?: string;
   refetchProposals?: () => void;
   searchTerm?: string;
-  osmosisBalances?: CombinedBalanceInfo[] | undefined;
-  isOsmosisBalancesLoading?: boolean;
-  refetchOsmosisBalances?: () => void;
-  resolveOsmosisRefetch?: () => void;
-  chains: Record<string, ChainContext>;
 }
 
-export function TokenList(props: Readonly<TokenListProps>) {
+export const TokenList = React.memo(function TokenList(props: Readonly<TokenListProps>) {
   const {
     balances,
     isLoading,
@@ -36,11 +31,6 @@ export function TokenList(props: Readonly<TokenListProps>) {
     admin,
     refetchProposals,
     searchTerm = '',
-    osmosisBalances,
-    isOsmosisBalancesLoading,
-    refetchOsmosisBalances,
-    resolveOsmosisRefetch,
-    chains,
   } = props;
   const [selectedDenom, setSelectedDenom] = useState<any>(null);
   const [isSendModalOpen, setIsSendModalOpen] = useState(false);
@@ -90,6 +80,8 @@ export function TokenList(props: Readonly<TokenListProps>) {
       )),
     [totalPages]
   );
+
+  const memoizedBalances = useMemo(() => props.balances ?? [], [props.balances]);
 
   return (
     <div className="w-full mx-auto rounded-[24px] h-full flex flex-col">
@@ -228,7 +220,7 @@ export function TokenList(props: Readonly<TokenListProps>) {
         modalId="send-modal"
         isOpen={isSendModalOpen}
         address={address}
-        balances={balances ?? []}
+        balances={memoizedBalances}
         isBalancesLoading={isLoading}
         refetchBalances={refetchBalances}
         refetchHistory={refetchHistory}
@@ -237,12 +229,7 @@ export function TokenList(props: Readonly<TokenListProps>) {
         isGroup={isGroup}
         admin={admin}
         refetchProposals={refetchProposals}
-        osmosisBalances={osmosisBalances ?? []}
-        isOsmosisBalancesLoading={isOsmosisBalancesLoading ?? false}
-        refetchOsmosisBalances={refetchOsmosisBalances ?? (() => {})}
-        resolveOsmosisRefetch={resolveOsmosisRefetch ?? (() => {})}
-        chains={chains}
       />
     </div>
   );
-}
+});

--- a/components/bank/modals/sendModal.tsx
+++ b/components/bank/modals/sendModal.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import SendBox from '../components/sendBox';
 import { CombinedBalanceInfo } from '@/utils/types';
-import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { ChainContext } from '@cosmos-kit/core';
 
@@ -18,14 +17,9 @@ interface SendModalProps {
   isGroup?: boolean;
   admin?: string;
   refetchProposals?: () => void;
-  osmosisBalances: CombinedBalanceInfo[];
-  isOsmosisBalancesLoading: boolean;
-  refetchOsmosisBalances: () => void;
-  resolveOsmosisRefetch: () => void;
-  chains: Record<string, ChainContext>;
 }
 
-export default function SendModal({
+export default React.memo(function SendModal({
   modalId,
   address,
   balances,
@@ -38,11 +32,6 @@ export default function SendModal({
   isGroup,
   admin,
   refetchProposals,
-  osmosisBalances,
-  isOsmosisBalancesLoading,
-  refetchOsmosisBalances,
-  resolveOsmosisRefetch,
-  chains,
 }: SendModalProps) {
   const handleClose = () => {
     if (setOpen) {
@@ -61,6 +50,8 @@ export default function SendModal({
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen]);
+
+  const memoizedBalances = useMemo(() => balances, [balances]);
 
   const modalContent = (
     <dialog
@@ -101,7 +92,7 @@ export default function SendModal({
 
         <SendBox
           address={address}
-          balances={balances}
+          balances={memoizedBalances}
           isBalancesLoading={isBalancesLoading}
           refetchBalances={refetchBalances}
           refetchHistory={refetchHistory}
@@ -109,11 +100,6 @@ export default function SendModal({
           isGroup={isGroup}
           admin={admin}
           refetchProposals={refetchProposals}
-          osmosisBalances={osmosisBalances}
-          isOsmosisBalancesLoading={isOsmosisBalancesLoading}
-          refetchOsmosisBalances={refetchOsmosisBalances}
-          resolveOsmosisRefetch={resolveOsmosisRefetch}
-          chains={chains}
         />
       </div>
       <form
@@ -140,4 +126,4 @@ export default function SendModal({
   }
 
   return null;
-}
+});

--- a/components/groups/components/groupControls.tsx
+++ b/components/groups/components/groupControls.tsx
@@ -604,7 +604,6 @@ export default function GroupControls({
               isGroup={true}
               admin={policyAddress}
               refetchProposals={refetchProposals}
-              chains={chains}
             />
           )}
         </div>

--- a/components/react/modal.tsx
+++ b/components/react/modal.tsx
@@ -36,8 +36,6 @@ import { Web3AuthClient, Web3AuthWallet } from '@cosmos-kit/web3auth';
 import { useDeviceDetect } from '@/hooks';
 import { State } from '@cosmos-kit/core';
 import { ExpiredError } from '@cosmos-kit/core';
-import env from '@/config/env';
-import { useChains } from '@cosmos-kit/react';
 
 export enum ModalView {
   WalletList,
@@ -94,25 +92,7 @@ export const TailwindModal: React.FC<
   const [qrState, setQRState] = useState<State>(State.Init);
   const [qrMessage, setQrMessage] = useState<string>('');
 
-  const chains = useChains([env.chain, env.osmosisChain, env.axelarChain]);
-
-  const chainStates = useMemo(() => {
-    return Object.values(chains).map(chain => ({
-      connect: chain.connect,
-      openView: chain.openView,
-      status: chain.status,
-      username: chain.username,
-      address: chain.address,
-      disconnect: chain.disconnect,
-    }));
-  }, [chains]);
-
-  const disconnect = async () => {
-    await Promise.all(chainStates.map(chain => chain.disconnect()));
-  };
-
-  const current = chains?.manifesttestnet?.walletRepo?.current;
-
+  const current = walletRepo?.current;
   const currentWalletData = current?.walletInfo;
   const walletStatus = current?.walletStatus || WalletStatus.Disconnected;
   const currentWalletName = current?.walletName;
@@ -464,7 +444,7 @@ export const TailwindModal: React.FC<
           <Connected
             onClose={onCloseModal}
             onReturn={() => setCurrentView(ModalView.WalletList)}
-            disconnect={() => disconnect()}
+            disconnect={() => current?.disconnect()}
             name={currentWalletData?.prettyName!}
             logo={currentWalletData?.logo!.toString() ?? ''}
             username={current?.username}

--- a/components/wallet.tsx
+++ b/components/wallet.tsx
@@ -2,7 +2,7 @@ import React, { MouseEventHandler, useEffect, useMemo, useState, useRef } from '
 
 import { ArrowDownTrayIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { ArrowUpIcon, CopyIcon } from './icons';
-import { useChain, useChains } from '@cosmos-kit/react';
+import { useChain } from '@cosmos-kit/react';
 import { WalletStatus } from 'cosmos-kit';
 import { MdWallet } from 'react-icons/md';
 import env from '@/config/env';
@@ -37,51 +37,7 @@ interface WalletSectionProps {
 }
 
 export const WalletSection: React.FC<WalletSectionProps> = ({ chainName }) => {
-  const chains = useChains([env.chain, env.osmosisChain, env.axelarChain]);
-
-  const chainStates = useMemo(() => {
-    return Object.values(chains).map(chain => ({
-      connect: chain.connect,
-      openView: chain.openView,
-      status: chain.status,
-      username: chain.username,
-      address: chain.address,
-      wallet: chain.wallet,
-    }));
-  }, [chains]);
-
-  const connect = async () => {
-    await Promise.all(chainStates.map(chain => chain.connect()));
-  };
-
-  const openView = () => {
-    chainStates[0]?.openView();
-  };
-
-  const status = useMemo(() => {
-    if (chainStates.some(chain => chain.status === WalletStatus.Connecting)) {
-      return WalletStatus.Connecting;
-    }
-    if (chainStates.some(chain => chain.status === WalletStatus.Error)) {
-      return WalletStatus.Error;
-    }
-    if (chainStates.every(chain => chain.status === WalletStatus.Connected)) {
-      return WalletStatus.Connected;
-    }
-    return WalletStatus.Disconnected;
-  }, [chainStates]);
-
-  const username = useMemo(
-    () => chainStates.find(chain => chain.username)?.username || undefined,
-    [chainStates]
-  );
-
-  const wallet = useMemo(() => chainStates.find(chain => chain.wallet)?.wallet, [chainStates]);
-
-  const address = useMemo(
-    () => chainStates.find(chain => chain.address)?.address || undefined,
-    [chainStates]
-  );
+  const { connect, openView, status, username, address, wallet } = useChain(chainName);
 
   const [localStatus, setLocalStatus] = useState(status);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();


### PR DESCRIPTION
This PR 
- reverts the omnibus change that supports connecting multiple chains with 1 wallet
- memoizes the components that pass along the combinedBalances data from the bank page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced UI performance by streamlining transaction components with improved rendering techniques.
	- Simplified wallet connection and token balance management for a more responsive and efficient user experience.
	- Reduced complexity by removing redundant interface elements, resulting in a cleaner and more maintainable design.
	- Updated handling of balances and props in key components to improve performance and reduce dependencies.
	- Removed unnecessary props related to Osmosis balances across multiple components for a more focused functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->