### PR TITLE
feat: ibc receive in tx history

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@liftedinit/manifestjs": "0.0.1-rc.1",
         "@react-three/drei": "^9.114.0",
         "@react-three/fiber": "^8.17.8",
-        "@skip-go/client": "^0.16.8",
+        "@skip-go/client": "^0.16.9",
         "@tanstack/react-query": "^5.55.0",
         "@tanstack/react-query-devtools": "^5.55.0",
         "@types/file-saver": "^2.0.7",

--- a/components/bank/handlers/ibc/index.ts
+++ b/components/bank/handlers/ibc/index.ts
@@ -1,1 +1,2 @@
+export * from './msgRecvPacketHandler';
 export * from './msgTransferHandler';

--- a/components/bank/handlers/ibc/msgRecvPacketHandler.tsx
+++ b/components/bank/handlers/ibc/msgRecvPacketHandler.tsx
@@ -1,0 +1,24 @@
+import { TransferIcon } from '@/components/icons/TransferIcon';
+import { createSenderReceiverHandler } from '../createSenderReceiverHandler';
+import { registerHandler } from '@/components/bank/handlers/handlerRegistry';
+import { MsgRecvPacket } from 'cosmjs-types/ibc/core/channel/v1/tx';
+import { createTokenMessage } from '@/components';
+
+export const MsgRecvPacketHandler = createSenderReceiverHandler({
+  iconSender: TransferIcon,
+  successSender: 'N/A',
+  failSender: 'N/A',
+  successReceiver: (tx, _, metadata) => {
+    const denom = tx.metadata?.decodedData?.denom?.replace(/transfer\/channel-\d+\//, '');
+    return createTokenMessage(
+      'You received {0} from {1} via IBC',
+      tx.metadata?.decodedData?.amount,
+      denom,
+      tx.sender,
+      'green',
+      metadata
+    );
+  },
+});
+
+registerHandler(MsgRecvPacket.typeUrl, MsgRecvPacketHandler);

--- a/components/bank/handlers/ibc/msgRecvPacketHandler.tsx
+++ b/components/bank/handlers/ibc/msgRecvPacketHandler.tsx
@@ -9,6 +9,12 @@ export const MsgRecvPacketHandler = createSenderReceiverHandler({
   successSender: 'N/A',
   failSender: 'N/A',
   successReceiver: (tx, _, metadata) => {
+    const requiredFields = ['amount', 'denom', 'sender', 'receiver']; // FungibleTokenPacketData fields (ICS-20)
+    const hasAllFields = requiredFields.every(field => field in (tx.metadata?.decodedData ?? {}));
+    if (!hasAllFields) {
+      return 'Unsupported IBC packet';
+    }
+
     const denom = tx.metadata?.decodedData?.denom?.replace(/transfer\/channel-\d+\//, '');
     return createTokenMessage(
       'You received {0} from {1} via IBC',

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -7,6 +7,10 @@ export function truncateString(str: string, prefixLen: number = 6, suffixLen: nu
 }
 
 export function truncateAddress(address: string, num: number = 24) {
+  if (address === null || address === undefined) {
+    console.warn('unable to truncate undefined/null address');
+    return '';
+  }
   if (address.length <= num) return address;
 
   return address.slice(0, num) + '...';

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -11,9 +11,8 @@ export function truncateAddress(address: string | null | undefined, num: number 
     console.warn('unable to truncate undefined/null address');
     return '';
   }
-  if (address.length <= num) return address;
 
-  return address.slice(0, num) + '...';
+  return address.length > num ? `${address.slice(0, num)}...` : address;
 }
 
 export function secondsToHumanReadable(seconds: number): string {

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -6,8 +6,8 @@ export function truncateString(str: string, prefixLen: number = 6, suffixLen: nu
   return str.slice(0, prefixLen) + '...' + str.slice(-suffixLen);
 }
 
-export function truncateAddress(address: string, num: number = 24) {
-  if (address === null || address === undefined) {
+export function truncateAddress(address: string | null | undefined, num: number = 24) {
+  if (address == null) {
     console.warn('unable to truncate undefined/null address');
     return '';
   }


### PR DESCRIPTION
This PR adds support for IBC Receive in the transaction history. For the time being, only fungible token transfers are supported.

Depends on https://github.com/liftedinit/yaci/pull/49
Fixes #259 

![2025-02-10_13-51_1](https://github.com/user-attachments/assets/162fa901-548d-49e0-a9b3-0dd987670799)
![2025-02-10_13-51](https://github.com/user-attachments/assets/7f6fb949-415c-437f-9014-614d959cadf1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced token receipt notifications for cross-chain transfers by validating incoming transaction details and formatting token receipt messages.

- **Bug Fixes**
  - Improved address formatting to gracefully handle missing or unexpected input, reducing potential runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->