### PR TITLE
fix: payout send handler

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@liftedinit/manifestjs": "0.0.1-rc.1",
         "@react-three/drei": "^9.114.0",
         "@react-three/fiber": "^8.17.8",
-        "@skip-go/client": "^0.16.8",
+        "@skip-go/client": "^0.16.9",
         "@tanstack/react-query": "^5.55.0",
         "@tanstack/react-query-devtools": "^5.55.0",
         "@types/file-saver": "^2.0.7",

--- a/components/bank/handlers/manifest/msgPayoutHandler.tsx
+++ b/components/bank/handlers/manifest/msgPayoutHandler.tsx
@@ -28,11 +28,15 @@ const createSendMessage = (
     </span>
   );
   const recipient =
-    pairs.length > 1
-      ? `distributed across ${pairs.length} addresses`
-      : pairs?.[0]?.address
-        ? `to ${(<TruncatedAddressWithCopy address={pairs[0].address} slice={24} />)}`
-        : 'an unknown address';
+    pairs.length > 1 ? (
+      `distributed across ${pairs.length} addresses`
+    ) : pairs?.[0]?.address ? (
+      <>
+        to <TruncatedAddressWithCopy address={pairs[0].address} slice={24} />{' '}
+      </>
+    ) : (
+      'an unknown address'
+    );
   const message = format(template, coloredAmount, recipient);
   return <span className="flex gap-1">{message}</span>;
 };


### PR DESCRIPTION
This PR fixes the address display of the `MsgPayout` handler.

![2025-02-12_11-10](https://github.com/user-attachments/assets/f608b0d9-cd35-4729-86bc-51793c720d3e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the display formatting for recipient addresses. The updated presentation now delivers a clearer and more consistent view, ensuring that address details remain easy to read across various scenarios without altering the existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->