### PR TITLE
fix: stabilize tx order in history

### DIFF
--- a/hooks/useQueries.ts
+++ b/hooks/useQueries.ts
@@ -904,7 +904,10 @@ export const useGetMessagesFromAddress = (
         const dateComparison = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
         if (dateComparison !== 0) return dateComparison;
         // If timestamps are equal, sort by block number descending
-        return b.height - a.height;
+        const blockComparison = b.height - a.height;
+        if (blockComparison !== 0) return blockComparison;
+        // If block numbers are equal, sort by index descending
+        return b.message_index - a.message_index;
       });
 
       return {


### PR DESCRIPTION
This PR stabilizes the transaction history order. The transactions are displayed in the same order when refreshing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced message ordering for a more consistent and intuitive display, ensuring that messages with similar characteristics are arranged in a refined sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->