### PR TITLE
fix: Allow people to mint/burn/send "fake MFX"

### DIFF
--- a/components/factory/components/DenomDisplay.tsx
+++ b/components/factory/components/DenomDisplay.tsx
@@ -1,6 +1,7 @@
 import { DenomImage, VerifiedIcon } from '@/components';
 import { formatTokenDisplay } from '@/utils';
 import React from 'react';
+import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank/v1beta1/bank';
 
 export const DenomVerifiedBadge = ({
   base,
@@ -16,10 +17,7 @@ export const DenomDisplay = ({
   metadata,
   withBackground,
 }: {
-  metadata?: {
-    display?: string;
-    base?: string;
-  } | null;
+  metadata?: MetadataSDKType | null;
   denom?: string;
   withBackground?: boolean;
 }) => {

--- a/components/factory/components/DenomImage.tsx
+++ b/components/factory/components/DenomImage.tsx
@@ -1,6 +1,7 @@
 import ProfileAvatar from '@/utils/identicon';
 import Image from 'next/image';
 import { useState, useEffect } from 'react';
+import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank/v1beta1/bank';
 
 export const supportedDomains = [
   'imgur.com',
@@ -68,7 +69,7 @@ export const DenomImage = ({
   denom,
   withBackground = true,
 }: {
-  denom: any;
+  denom?: MetadataSDKType | null;
   withBackground?: boolean;
 }) => {
   const [imageError, setImageError] = useState(false);
@@ -76,13 +77,14 @@ export const DenomImage = ({
   const [isSupported, setIsSupported] = useState(false);
 
   useEffect(() => {
-    const checkUri = async () => {
+    const checkUri = () => {
       if (denom?.uri) {
         setIsSupported(isUrlSupported(denom?.uri));
         // Simulate a delay to show the loading state
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        setTimeout(() => setIsLoading(false), 1000);
+      } else {
+        setIsLoading(false);
       }
-      setIsLoading(false);
     };
 
     checkUri();
@@ -98,7 +100,7 @@ export const DenomImage = ({
   }
 
   // Check for MFX token first
-  if (denom?.base?.includes('umfx') || denom?.base?.includes('uosmo')) {
+  if (denom?.base === 'umfx' || denom?.base?.includes('uosmo')) {
     return (
       <div
         className={`w-11 h-11 p-2 rounded-md ${withBackground ? 'dark:bg-[#ffffff0f] bg-[#0000000a]' : ''}`}
@@ -106,7 +108,7 @@ export const DenomImage = ({
         <Image
           width={44}
           height={44}
-          src={denom?.base?.includes('umfx') ? '/logo.svg' : '/osmosis.svg'}
+          src={denom?.base === 'umfx' ? '/logo.svg' : '/osmosis.svg'}
           alt="MFX Token Icon"
           className="w-full h-full "
         />

--- a/components/factory/components/DenomList.tsx
+++ b/components/factory/components/DenomList.tsx
@@ -507,7 +507,7 @@ function TokenRow({
           </button>
 
           <button
-            disabled={denom.base.includes('umfx')}
+            disabled={denom.base === 'umfx'}
             className="btn btn-md bg-base-300 text-primary btn-square group-hover:bg-secondary hover:outline hover:outline-primary hover:outline-1 outline-none"
             onClick={onBurn}
           >
@@ -515,7 +515,7 @@ function TokenRow({
           </button>
 
           <button
-            disabled={denom.base.includes('umfx')}
+            disabled={denom.base === 'umfx'}
             className="btn btn-md bg-base-300 text-primary btn-square group-hover:bg-secondary hover:outline hover:outline-primary hover:outline-1 outline-none"
             onClick={onTransfer}
           >
@@ -523,7 +523,7 @@ function TokenRow({
           </button>
 
           <button
-            disabled={denom.base.includes('umfx')}
+            disabled={denom.base === 'umfx'}
             className="btn btn-md bg-base-300 text-primary btn-square group-hover:bg-secondary hover:outline hover:outline-primary hover:outline-1 outline-none"
             onClick={onUpdate}
           >

--- a/components/factory/forms/BurnForm.tsx
+++ b/components/factory/forms/BurnForm.tsx
@@ -57,7 +57,7 @@ export default function BurnForm({
   const { submitProposal } = cosmos.group.v1.MessageComposer.withTypeUrl;
   const { setToastMessage } = useToast();
   const exponent = denom?.denom_units?.find(unit => unit.denom === denom.display)?.exponent || 0;
-  const isMFX = denom.base.includes('mfx');
+  const isMFX = denom?.base === 'umfx';
 
   const { balance: recipientBalance } = useTokenFactoryBalance(recipient ?? '', denom.base);
   const balanceNumber = useMemo(
@@ -241,7 +241,7 @@ export default function BurnForm({
                 </div>
               </div>
             </div>
-            {!denom.base.includes('umfx') && (
+            {!isMFX && (
               <Formik
                 initialValues={{ amount: '', recipient: address }}
                 validationSchema={BurnSchema}

--- a/components/factory/forms/BurnForm.tsx
+++ b/components/factory/forms/BurnForm.tsx
@@ -215,7 +215,7 @@ export default function BurnForm({
       <div className="rounded-lg">
         {isMFX && !isAdmin ? (
           <div className="w-full p-2 justify-center items-center my-auto leading-tight text-xl flex flex-col font-medium text-pretty">
-            <span>You must be apart of the admin group to burn MFX.</span>
+            <span>You must be a member of the admin group to burn MFX.</span>
           </div>
         ) : (
           <>

--- a/components/factory/forms/MintForm.tsx
+++ b/components/factory/forms/MintForm.tsx
@@ -41,7 +41,7 @@ export default function MintForm({
   const { mint } = osmosis.tokenfactory.v1beta1.MessageComposer.withTypeUrl;
   const { submitProposal } = cosmos.group.v1.MessageComposer.withTypeUrl;
 
-  const isMFX = denom.base.includes('mfx');
+  const isMFX = denom.base === 'umfx';
 
   const MintSchema = Yup.object().shape({
     amount: Yup.number().positive('Amount must be positive').required('Amount is required'),
@@ -135,7 +135,7 @@ export default function MintForm({
                 </div>
               </div>
             </div>
-            {!denom.base.includes('umfx') && (
+            {!isMFX && (
               <Formik
                 initialValues={{ amount: '', recipient: address }}
                 validationSchema={MintSchema}
@@ -210,7 +210,7 @@ export default function MintForm({
                       </div>
                     </div>
                     <div className="flex justify-end mt-6">
-                      {!denom.base.includes('umfx') && (
+                      {!isMFX && (
                         <button
                           type="submit"
                           aria-label={`mint-btn-${denom.display}`}

--- a/components/factory/forms/__tests__/BurnForm.test.tsx
+++ b/components/factory/forms/__tests__/BurnForm.test.tsx
@@ -2,7 +2,7 @@ import { describe, test, afterEach, expect, jest, mock } from 'bun:test';
 import React from 'react';
 import { screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import BurnForm from '@/components/factory/forms/BurnForm';
-import { manifestAddr1, mockDenomMeta1, mockMfxDenom } from '@/tests/mock';
+import { manifestAddr1, mockDenomMeta1, mockMfxDenom, mockFakeMfxDenom } from '@/tests/mock';
 import { renderWithChainProvider } from '@/tests/render';
 
 // Mock next/router
@@ -24,7 +24,7 @@ mock.module('@/hooks/useQueries', () => ({
 const mockProps = {
   isAdmin: true,
   admin: 'cosmos1adminaddress',
-  denom: mockDenomMeta1,
+  denom: { ...mockDenomMeta1, balance: '1000000', totalSupply: '1000000' },
   address: 'cosmos1address',
   refetch: jest.fn(),
   balance: '1000000',
@@ -91,5 +91,19 @@ describe('BurnForm Component', () => {
     renderWithProps();
     const burnButton = screen.getByLabelText(`burn-btn-${mockDenomMeta1.base}`);
     expect(burnButton).toBeDisabled();
+  });
+
+  test('fake MFX can be burnt', async () => {
+    renderWithProps({ isAdmin: false, denom: mockFakeMfxDenom });
+    const amountInput = screen.getByPlaceholderText('Enter amount');
+    const recipientInput = screen.getByPlaceholderText('Recipient address');
+    const burnButton = screen.getByLabelText(`burn-btn-${mockFakeMfxDenom.base}`);
+
+    fireEvent.change(amountInput, { target: { value: '100' } });
+    fireEvent.change(recipientInput, { target: { value: manifestAddr1 } });
+
+    await waitFor(() => {
+      expect(burnButton).toBeEnabled();
+    });
   });
 });

--- a/components/factory/forms/__tests__/BurnForm.test.tsx
+++ b/components/factory/forms/__tests__/BurnForm.test.tsx
@@ -47,7 +47,7 @@ describe('BurnForm Component', () => {
   test('renders not affiliated message when not admin and token is mfx', () => {
     renderWithProps({ isAdmin: false, denom: mockMfxDenom });
     expect(
-      screen.getByText('You must be apart of the admin group to burn MFX.')
+      screen.getByText('You must be a member of the admin group to burn MFX.')
     ).toBeInTheDocument();
   });
 

--- a/components/factory/forms/__tests__/MintForm.test.tsx
+++ b/components/factory/forms/__tests__/MintForm.test.tsx
@@ -41,6 +41,13 @@ describe('MintForm Component', () => {
     expect(screen.getByText('CIRCULATING SUPPLY')).toBeInTheDocument();
   });
 
+  test('renders not affiliated message when not admin and token is mfx', () => {
+    renderWithProps({ isAdmin: false, denom: mockMfxDenom });
+    expect(
+      screen.getByText('You must be a member of the admin group to mint MFX.')
+    ).toBeInTheDocument();
+  });
+
   test('updates amount input correctly', async () => {
     renderWithProps();
     const amountInput = screen.getByLabelText('AMOUNT');

--- a/components/factory/forms/__tests__/MintForm.test.tsx
+++ b/components/factory/forms/__tests__/MintForm.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import MintForm from '@/components/factory/forms/MintForm';
 import { renderWithChainProvider } from '@/tests/render';
-import { mockDenomMeta1, mockMfxDenom } from '@/tests/mock';
+import { mockDenomMeta1, mockFakeMfxDenom, mockMfxDenom } from '@/tests/mock';
 
 // Mock next/router
 const m = jest.fn();
@@ -17,7 +17,11 @@ mock.module('next/router', () => ({
 const mockProps = {
   isAdmin: true,
   admin: 'cosmos1adminaddress',
-  denom: mockDenomMeta1,
+  denom: {
+    ...mockDenomMeta1,
+    balance: '1000000',
+    totalSupply: '1000000',
+  },
   address: 'cosmos1address',
   refetch: jest.fn(),
   balance: '1000000',
@@ -73,6 +77,22 @@ describe('MintForm Component', () => {
     const amountInput = screen.getByLabelText('AMOUNT');
     const recipientInput = screen.getByLabelText('RECIPIENT');
     const mintButton = screen.getByLabelText(`mint-btn-${mockDenomMeta1.display}`);
+
+    fireEvent.change(amountInput, { target: { value: '1' } });
+    fireEvent.change(recipientInput, {
+      target: { value: 'manifest1aucdev30u9505dx9t6q5fkcm70sjg4rh7rn5nf' },
+    });
+
+    await waitFor(() => {
+      expect(mintButton).toBeEnabled();
+    });
+  });
+
+  test('fake MFX can be minted', async () => {
+    renderWithProps({ isAdmin: false, denom: mockFakeMfxDenom });
+    const amountInput = screen.getByLabelText('AMOUNT');
+    const recipientInput = screen.getByLabelText('RECIPIENT');
+    const mintButton = screen.getByLabelText(`mint-btn-${mockFakeMfxDenom.display}`);
 
     fireEvent.change(amountInput, { target: { value: '1' } });
     fireEvent.change(recipientInput, {

--- a/tests/mock.ts
+++ b/tests/mock.ts
@@ -520,6 +520,16 @@ export const mockMfxDenom = {
   symbol: 'umfx',
 };
 
+export const mockFakeMfxDenom = {
+  base: 'TEST_umfx_TEST',
+  display: 'MFX',
+  denom_units: [
+    { denom: 'umfx', exponent: 0, aliases: ['umfx'] },
+    { denom: 'mfx', exponent: 6, aliases: ['mfx'] },
+  ],
+  symbol: 'umfx',
+};
+
 const { send } = cosmos.bank.v1beta1.MessageComposer.withTypeUrl;
 const msg = send({
   fromAddress: 'fromaddress123',

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,6 +1,7 @@
 import { ExtendedMetadataSDKType } from './types';
+import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank/v1beta1/bank';
 
-export const MFX_TOKEN_DATA: Omit<ExtendedMetadataSDKType, 'balance' | 'totalSupply'> = {
+export const MFX_TOKEN_DATA: MetadataSDKType = {
   description: 'The native token of the Manifest Chain',
   denom_units: [
     { denom: 'umfx', exponent: 0, aliases: [] },
@@ -14,7 +15,7 @@ export const MFX_TOKEN_DATA: Omit<ExtendedMetadataSDKType, 'balance' | 'totalSup
   uri_hash: '',
 };
 
-export const OSMOSIS_TOKEN_DATA: Omit<ExtendedMetadataSDKType, 'balance' | 'totalSupply'> = {
+export const OSMOSIS_TOKEN_DATA: MetadataSDKType = {
   description: 'The native token of the Osmosis Chain',
   denom_units: [
     { denom: 'uosmo', exponent: 0, aliases: [] },

--- a/utils/identicon.tsx
+++ b/utils/identicon.tsx
@@ -8,7 +8,7 @@ const ProfileAvatar = ({
   size,
   withBackground = true,
 }: {
-  walletAddress: string;
+  walletAddress?: string;
   size?: number;
   withBackground?: boolean;
 }) => {


### PR DESCRIPTION
The current flow looks for any mention of mfx in the denomination so even tokens that dont want to fake MFX but use MFX in the name would not be mint or burn-able. This fixes it.

Real umfx tokens should still not be able to be burnt or minted. The verified badge will not show up for fake MFX tokens so this should not be confusing to the user.

Fixes #249
Fixes #248 

----

![CleanShot 2025-02-13 at 12 01 25@2x](https://github.com/user-attachments/assets/bbf7b359-7d20-4fa9-84b4-3cc87bafd54b)

----

![CleanShot 2025-02-13 at 11 59 32@2x](https://github.com/user-attachments/assets/b82c3351-8609-4cd5-b52f-5148e3d6408e)
----


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Refined token metadata handling and conditional logic for UI elements in token displays, forms, and icon generation.
  - Enhanced type safety and consistency across multiple components and constants.

- **Tests**
  - Expanded test coverage with new scenarios for minting and burning actions using a newly introduced dummy token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->