### PR TITLE
fix: mobile proposal detail render

### DIFF
--- a/components/groups/modals/voteDetailsModal.tsx
+++ b/components/groups/modals/voteDetailsModal.tsx
@@ -38,7 +38,7 @@ interface VoteDetailsModalProps {
   showVoteModal: boolean;
   onClose: () => void;
 }
-// Default fields to show if the message type is not in the mapping
+
 function VoteDetailsModal({
   policyAddress,
   proposalId,
@@ -236,18 +236,6 @@ function VoteDetailsModal({
                   }
                 }}
               />
-            </div>
-            <div className="text-right">
-              {userHasVoted && (
-                <div className="text-right mt-2">
-                  <span className="text-sm text-primary-content">Your vote:</span>
-                  <span
-                    className={`badge badge-lg rounded-full ${getVoteOptionBadgeColor(userVoteOption)}`}
-                  >
-                    {userVoteOption ? getVoteOptionLabel(userVoteOption) : null}
-                  </span>
-                </div>
-              )}
             </div>
           </div>
 

--- a/components/groups/utils.tsx
+++ b/components/groups/utils.tsx
@@ -31,26 +31,27 @@ export function getProposalButton(
           return undefined;
         case ProposalStatus.PROPOSAL_STATUS_SUBMITTED:
           return (
-            <div className="flex flex-row items-center justify-center gap-2">
+            <div className="flex flex-row items-stretch justify-center gap-2">
               {pollForData ? (
-                <div className="flex flex-row items-center justify-center gap-2">
-                  <div className="text-secondary-content">
-                    The proposal is getting accepted. Please wait
+                <div className="flex flex-col items-center justify-center gap-2">
+                  <div className="text-secondary-content">The proposal is getting processed.</div>
+                  <div className="flex flex-row items-center justify-center gap-2">
+                    <div className="text-secondary-content">Please wait</div>
+                    <div className="loading loading-dots loading-sm" />
                   </div>
-                  <div className="loading loading-dots loading-sm" />
                 </div>
               ) : (
                 <>
                   {isProposer && (
                     <button
-                      className={`btn btn-error text-white rounded-[12px] ${userVoteOption ? 'w-full' : 'w-1/2'}`}
+                      className={`btn btn-error text-white rounded-[12px] w-1/2`}
                       disabled={isSigning}
                       onClick={executeWithdrawal}
                     >
                       {isSigning ? <div className="loading loading-dots loading-sm" /> : 'Withdraw'}
                     </button>
                   )}
-                  {!userVoteOption && (
+                  {!userVoteOption ? (
                     <button
                       className={`btn btn-gradient text-white rounded-[12px] ${isProposer ? 'w-1/2' : 'w-full'}`}
                       disabled={isSigning}
@@ -58,6 +59,12 @@ export function getProposalButton(
                     >
                       {isSigning ? <div className="loading loading-dots loading-sm" /> : 'Vote'}
                     </button>
+                  ) : (
+                    <div
+                      className={`flex min-h-12 items-center justify-center text-white rounded-[12px] px-3 py-1 font-semibold ${isProposer ? 'w-1/2' : 'w-full'} ${getVoteOptionBadgeColor(userVoteOption)}`}
+                    >
+                      You voted {userVoteOption ? getVoteOptionLabel(userVoteOption) : null}
+                    </div>
                   )}
                 </>
               )}


### PR DESCRIPTION
Fix small UI issues when displaying the proposal detail on mobile.

## BEFORE
![signal-2025-02-20-195005_002](https://github.com/user-attachments/assets/02756ed4-0f69-497e-8437-025579248a4b)
![signal-2025-02-20-195005_003](https://github.com/user-attachments/assets/ed82e382-80be-409b-995d-b2745812faac)


## AFTER
![2025-02-21_09-56](https://github.com/user-attachments/assets/2b89a0f1-d9d2-422f-9915-ae86a79d8b16)
![2025-02-21_09-57](https://github.com/user-attachments/assets/b5f02c16-6ec3-4402-889e-81f30de443de)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the proposal interface with clearer status messages, a refined layout including a loading indicator, and a dedicated display for your vote when applicable.
- **Refactor**
  - Streamlined the voting modal by removing redundant vote status feedback for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->