### PR TITLE
fix: if authors is already an array, dont make it an array

### DIFF
--- a/components/groups/modals/__tests__/UpdateGroupModal.test.tsx
+++ b/components/groups/modals/__tests__/UpdateGroupModal.test.tsx
@@ -19,7 +19,7 @@ const mockProps = {
     id: '1',
     admin: 'admin_address',
     metadata:
-      '{"title":"Test Group","authors":"Test Author","summary":"Test Summary","proposalForumURL":"https://example.com","details":"Test Description"}',
+      '{"title":"Test Group","authors":["Test Author"],"summary":"Test Summary","proposalForumURL":"https://example.com","details":"Test Description"}',
     members: [
       {
         group_id: '1',

--- a/components/groups/modals/updateGroupModal.tsx
+++ b/components/groups/modals/updateGroupModal.tsx
@@ -60,7 +60,9 @@ export function UpdateGroupModal({
     cosmos.group.v1.MessageComposer.withTypeUrl;
 
   const [name, setName] = useState(maybeTitle);
-  const [authors, setAuthors] = useState(maybeAuthors ? [maybeAuthors] : []);
+  const [authors, setAuthors] = useState(
+    maybeAuthors ? (Array.isArray(maybeAuthors) ? maybeAuthors : [maybeAuthors]) : []
+  );
   const [description, setDescription] = useState(maybeDetails);
   const [threshold, setThreshold] = useState(maybeThreshold !== '' ? maybeThreshold : '1');
   const [votingPeriod, setVotingPeriod] = useState({


### PR DESCRIPTION
Fixes #265


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the handling of author information to consistently use a list format.
  - Improved the modal’s initialization logic for author entries, ensuring reliable support for both single and multiple values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->