### PR TITLE
refactor: remove building the DOM of all groups info for all rows

### DIFF
--- a/components/groups/components/myGroups.tsx
+++ b/components/groups/components/myGroups.tsx
@@ -593,7 +593,7 @@ function GroupRow({
     <>
       <tr
         className="group text-black dark:text-white rounded-lg cursor-pointer"
-        onClick={e => onSelectGroup(group)}
+        onClick={() => onSelectGroup(group)}
         tabIndex={0}
         role="button"
         aria-label={`Select ${groupName} group`}
@@ -648,41 +648,41 @@ function GroupRow({
             </button>
           </div>
         </td>
+
+        {showInfo && (
+          <GroupInfo
+            group={group}
+            address={address ?? ''}
+            policyAddress={group.policies[0]?.address ?? ''}
+            onUpdate={refetch}
+            showInfoModal={showInfo}
+            setShowInfoModal={show => setShowInfo(show)}
+          />
+        )}
+
+        {showMembers && (
+          <MemberManagementModal
+            members={group.members.map(member => ({
+              ...member.member,
+              address: member?.member?.address || '',
+              weight: member?.member?.weight || '0',
+              metadata: member?.member?.metadata || '',
+              added_at: member?.member?.added_at || new Date(),
+              isCoreMember: true,
+              isActive: true,
+              isAdmin: member?.member?.address === group.admin,
+              isPolicyAdmin: member?.member?.address === group.policies[0]?.admin,
+            }))}
+            groupId={group.id.toString()}
+            groupAdmin={group.admin}
+            policyAddress={group.policies[0]?.address ?? ''}
+            address={address ?? ''}
+            onUpdate={refetch}
+            setShowMemberManagementModal={show => setShowMembers(show)}
+            showMemberManagementModal={showMembers}
+          />
+        )}
       </tr>
-
-      {showInfo && (
-        <GroupInfo
-          group={group}
-          address={address ?? ''}
-          policyAddress={group.policies[0]?.address ?? ''}
-          onUpdate={refetch}
-          showInfoModal={showInfo}
-          setShowInfoModal={show => setShowInfo(show)}
-        />
-      )}
-
-      {showMembers && (
-        <MemberManagementModal
-          members={group.members.map(member => ({
-            ...member.member,
-            address: member?.member?.address || '',
-            weight: member?.member?.weight || '0',
-            metadata: member?.member?.metadata || '',
-            added_at: member?.member?.added_at || new Date(),
-            isCoreMember: true,
-            isActive: true,
-            isAdmin: member?.member?.address === group.admin,
-            isPolicyAdmin: member?.member?.address === group.policies[0]?.admin,
-          }))}
-          groupId={group.id.toString()}
-          groupAdmin={group.admin}
-          policyAddress={group.policies[0]?.address ?? ''}
-          address={address ?? ''}
-          onUpdate={refetch}
-          setShowMemberManagementModal={show => setShowMembers(show)}
-          showMemberManagementModal={showMembers}
-        />
-      )}
     </>
   );
 }

--- a/components/groups/components/myGroups.tsx
+++ b/components/groups/components/myGroups.tsx
@@ -406,6 +406,7 @@ export function YourGroups({
                         ))
                     : paginatedGroupEntries.map((group, index) => (
                         <GroupRow
+                          address={address}
                           key={index}
                           group={group}
                           proposals={
@@ -416,10 +417,7 @@ export function YourGroups({
                               : []
                           }
                           onSelectGroup={handleSelectGroup}
-                          activeMemberModalId={activeMemberModalId}
-                          setActiveMemberModalId={setActiveMemberModalId}
-                          activeInfoModalId={activeInfoModalId}
-                          setActiveInfoModalId={setActiveInfoModalId}
+                          refetch={refetch}
                         />
                       ))}
                 </tbody>
@@ -542,66 +540,26 @@ export function YourGroups({
           />
         )}
       </div>
-
-      {/* Render modals outside table structure */}
-      {filteredGroups.map((group, index) => (
-        <React.Fragment key={`modals-${index}`}>
-          <GroupInfo
-            modalId={`group-info-modal-${group.id}`}
-            group={group}
-            address={address ?? ''}
-            policyAddress={group.policies[0]?.address ?? ''}
-            onUpdate={refetch}
-            showInfoModal={activeInfoModalId === group.id.toString()}
-            setShowInfoModal={show => setActiveInfoModalId(show ? group.id.toString() : null)}
-          />
-          <MemberManagementModal
-            modalId={`member-management-modal-${group.id}`}
-            members={group.members.map(member => ({
-              ...member.member,
-              address: member?.member?.address || '',
-              weight: member?.member?.weight || '0',
-              metadata: member?.member?.metadata || '',
-              added_at: member?.member?.added_at || new Date(),
-              isCoreMember: true,
-              isActive: true,
-              isAdmin: member?.member?.address === group.admin,
-              isPolicyAdmin: member?.member?.address === group.policies[0]?.admin,
-            }))}
-            groupId={group.id.toString()}
-            groupAdmin={group.admin}
-            policyAddress={group.policies[0]?.address ?? ''}
-            address={address ?? ''}
-            onUpdate={refetch}
-            setShowMemberManagementModal={show =>
-              setActiveMemberModalId(show ? group.id.toString() : null)
-            }
-            showMemberManagementModal={activeMemberModalId === group.id.toString()}
-          />
-        </React.Fragment>
-      ))}
     </div>
   );
 }
 
 function GroupRow({
+  address,
   group,
   proposals,
   onSelectGroup,
-  activeMemberModalId,
-  setActiveMemberModalId,
-  activeInfoModalId,
-  setActiveInfoModalId,
+  refetch,
 }: {
+  address: string | undefined;
   group: ExtendedQueryGroupsByMemberResponseSDKType['groups'][0];
   proposals: ProposalSDKType[];
   onSelectGroup: (group: ExtendedGroupType) => void;
-
-  activeMemberModalId: string | null;
-  setActiveMemberModalId: (id: string | null) => void;
-  activeInfoModalId: string | null;
-  setActiveInfoModalId: (id: string | null) => void;
+  refetch: () => Promise<unknown>;
 }) {
+  const [showInfo, setShowInfo] = useState(false);
+  const [showMembers, setShowMembers] = useState(false);
+
   const policyAddress = (group.policies && group.policies[0]?.address) || '';
   let groupName = 'Untitled Group';
   try {
@@ -623,72 +581,108 @@ function GroupRow({
 
   const openInfoModal = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setActiveInfoModalId(group.id ? group.id.toString() : null);
+    setShowInfo(true);
   };
 
   const openMemberModal = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setActiveMemberModalId(group.id ? group.id.toString() : null);
+    setShowMembers(true);
   };
 
   return (
-    <tr
-      className="group text-black dark:text-white rounded-lg cursor-pointer"
-      onClick={() => onSelectGroup(group)}
-      tabIndex={0}
-      role="button"
-      aria-label={`Select ${groupName} group`}
-    >
-      <td className="bg-secondary group-hover:bg-base-300 rounded-l-[12px] w-1/6">
-        <div className="items-center space-x-3 hidden xs:flex">
-          <ProfileAvatar walletAddress={policyAddress} />
-          <span className="font-medium">{truncateString(groupName, 24)}</span>
-        </div>
-        <div className="items-center flex xs:hidden block">
-          <ProfileAvatar walletAddress={policyAddress} />
-        </div>
-      </td>
-      <td className="bg-secondary group-hover:bg-base-300 hidden xl:table-cell w-1/6">
-        {activeProposals.length > 0 ? (
-          <span className="badge badge-primary badge-sm text-neutral-content">
-            {activeProposals.length}
-          </span>
-        ) : (
-          '-'
-        )}
-      </td>
-      <td className="bg-secondary group-hover:bg-base-300 hidden sm:table-cell w-1/6">
-        {Number(shiftDigits(balance?.amount ?? '0', -6)).toLocaleString(undefined, {
-          maximumFractionDigits: 6,
-        })}{' '}
-        MFX
-      </td>
-      <td className="bg-secondary group-hover:bg-base-300 hidden xl:table-cell w-1/6">
-        {`${(group.policies?.[0]?.decision_policy as ThresholdDecisionPolicySDKType)?.threshold ?? '0'} / ${group.total_weight ?? '0'}`}
-      </td>
-      <td className="bg-secondary group-hover:bg-base-300 hidden lg:table-cell w-1/6">
-        <div onClick={e => e.stopPropagation()}>
-          <TruncatedAddressWithCopy address={policyAddress} />
-        </div>
-      </td>
-      <td className="bg-secondary group-hover:bg-base-300 rounded-r-[12px] sm:rounded-l-none w-1/6">
-        <div className="flex space-x-2 justify-end">
-          <button
-            className="btn btn-md bg-base-300 text-primary btn-square group-hover:bg-secondary hover:outline hover:outline-primary hover:outline-1 outline-none"
-            onClick={openInfoModal}
-            aria-label={`View info for ${groupName}`}
-          >
-            <PiInfo className="w-7 h-7 text-current" />
-          </button>
-          <button
-            className="btn btn-md bg-base-300 text-primary btn-square group-hover:bg-secondary hover:outline hover:outline-primary hover:outline-1 outline-none"
-            onClick={openMemberModal}
-            aria-label={`Manage members for ${groupName}`}
-          >
-            <MemberIcon className="w-7 h-7 text-current" />
-          </button>
-        </div>
-      </td>
-    </tr>
+    <>
+      <tr
+        className="group text-black dark:text-white rounded-lg cursor-pointer"
+        onClick={e => onSelectGroup(group)}
+        tabIndex={0}
+        role="button"
+        aria-label={`Select ${groupName} group`}
+      >
+        <td className="bg-secondary group-hover:bg-base-300 rounded-l-[12px] w-1/6">
+          <div className="items-center space-x-3 hidden xs:flex">
+            <ProfileAvatar walletAddress={policyAddress} />
+            <span className="font-medium">{truncateString(groupName, 24)}</span>
+          </div>
+          <div className="items-center flex xs:hidden block">
+            <ProfileAvatar walletAddress={policyAddress} />
+          </div>
+        </td>
+        <td className="bg-secondary group-hover:bg-base-300 hidden xl:table-cell w-1/6">
+          {activeProposals.length > 0 ? (
+            <span className="badge badge-primary badge-sm text-neutral-content">
+              {activeProposals.length}
+            </span>
+          ) : (
+            '-'
+          )}
+        </td>
+        <td className="bg-secondary group-hover:bg-base-300 hidden sm:table-cell w-1/6">
+          {Number(shiftDigits(balance?.amount ?? '0', -6)).toLocaleString(undefined, {
+            maximumFractionDigits: 6,
+          })}{' '}
+          MFX
+        </td>
+        <td className="bg-secondary group-hover:bg-base-300 hidden xl:table-cell w-1/6">
+          {`${(group.policies?.[0]?.decision_policy as ThresholdDecisionPolicySDKType)?.threshold ?? '0'} / ${group.total_weight ?? '0'}`}
+        </td>
+        <td className="bg-secondary group-hover:bg-base-300 hidden lg:table-cell w-1/6">
+          <div onClick={e => e.stopPropagation()}>
+            <TruncatedAddressWithCopy address={policyAddress} />
+          </div>
+        </td>
+        <td className="bg-secondary group-hover:bg-base-300 rounded-r-[12px] sm:rounded-l-none w-1/6">
+          <div className="flex space-x-2 justify-end">
+            <button
+              className="btn btn-md bg-base-300 text-primary btn-square group-hover:bg-secondary hover:outline hover:outline-primary hover:outline-1 outline-none"
+              onClick={openInfoModal}
+              aria-label={`View info for ${groupName}`}
+            >
+              <PiInfo className="w-7 h-7 text-current" />
+            </button>
+            <button
+              className="btn btn-md bg-base-300 text-primary btn-square group-hover:bg-secondary hover:outline hover:outline-primary hover:outline-1 outline-none"
+              onClick={openMemberModal}
+              aria-label={`Manage members for ${groupName}`}
+            >
+              <MemberIcon className="w-7 h-7 text-current" />
+            </button>
+          </div>
+        </td>
+      </tr>
+
+      {showInfo && (
+        <GroupInfo
+          group={group}
+          address={address ?? ''}
+          policyAddress={group.policies[0]?.address ?? ''}
+          onUpdate={refetch}
+          showInfoModal={showInfo}
+          setShowInfoModal={show => setShowInfo(show)}
+        />
+      )}
+
+      {showMembers && (
+        <MemberManagementModal
+          members={group.members.map(member => ({
+            ...member.member,
+            address: member?.member?.address || '',
+            weight: member?.member?.weight || '0',
+            metadata: member?.member?.metadata || '',
+            added_at: member?.member?.added_at || new Date(),
+            isCoreMember: true,
+            isActive: true,
+            isAdmin: member?.member?.address === group.admin,
+            isPolicyAdmin: member?.member?.address === group.policies[0]?.admin,
+          }))}
+          groupId={group.id.toString()}
+          groupAdmin={group.admin}
+          policyAddress={group.policies[0]?.address ?? ''}
+          address={address ?? ''}
+          onUpdate={refetch}
+          setShowMemberManagementModal={show => setShowMembers(show)}
+          showMemberManagementModal={showMembers}
+        />
+      )}
+    </>
   );
 }

--- a/components/groups/modals/__tests__/UpdateGroupModal.test.tsx
+++ b/components/groups/modals/__tests__/UpdateGroupModal.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { UpdateGroupModal } from '@/components';
 import { renderWithChainProvider } from '@/tests/render';
+import { ExtendedGroupType } from '@/hooks';
 
 // Mock next/router
 const m = jest.fn();
@@ -13,39 +14,47 @@ mock.module('next/router', () => ({
   }),
 }));
 
+const mockGroup: ExtendedGroupType = {
+  id: 1n,
+  admin: 'admin_address',
+  metadata:
+    '{"title":"Test Group","authors":"Test Author","summary":"Test Summary","proposalForumURL":"https://example.com","details":"Test Description"}',
+  members: [
+    {
+      group_id: 1n,
+      member: {
+        address: 'member1_address',
+        metadata: 'Member 1',
+        weight: '1',
+        added_at: new Date(),
+      },
+    },
+  ],
+  policies: [
+    {
+      group_id: 1n,
+      address: 'policy_address',
+      admin: 'admin_address',
+      decision_policy: {
+        threshold: '1',
+        windows: {
+          voting_period: { seconds: 86400n, nanos: 0 },
+          min_execution_period: { seconds: 86400n, nanos: 0 },
+        },
+      },
+      metadata: '',
+      version: 0n,
+      created_at: new Date(),
+    },
+  ],
+  total_weight: '',
+  version: 0n,
+  created_at: new Date(),
+};
+
 // Mock group data
 const mockProps = {
-  group: {
-    id: '1',
-    admin: 'admin_address',
-    metadata:
-      '{"title":"Test Group","authors":"Test Author","summary":"Test Summary","proposalForumURL":"https://example.com","details":"Test Description"}',
-    members: [
-      {
-        group_id: '1',
-        member: {
-          address: 'member1_address',
-          metadata: 'Member 1',
-          weight: '1',
-          added_at: new Date(),
-          isCoreMember: true,
-          isActive: true,
-        },
-      },
-    ],
-    policies: [
-      {
-        address: 'policy_address',
-        admin: 'admin_address',
-        decision_policy: {
-          threshold: '1',
-          windows: {
-            voting_period: '86400s',
-          },
-        },
-      },
-    ],
-  },
+  group: mockGroup,
   address: 'group_address',
   modalId: 'test-modal',
   policyAddress: 'policy_address',

--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -166,7 +166,7 @@ export function GroupInfo({
 
   const modalContent = (
     <Dialog
-      open={showInfoModal}
+      open
       onClose={() => setShowInfoModal(false)}
       className={`modal modal-open fixed flex p-0 m-0 z-0`}
       style={{

--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -166,7 +166,7 @@ export function GroupInfo({
 
   const modalContent = (
     <Dialog
-      open
+      open={showInfoModal}
       onClose={() => setShowInfoModal(false)}
       className={`modal modal-open fixed flex p-0 m-0 z-0`}
       style={{

--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -6,7 +6,7 @@ import { ThresholdDecisionPolicySDKType } from '@liftedinit/manifestjs/dist/code
 import { useFeeEstimation, useTx } from '@/hooks';
 import { cosmos } from '@liftedinit/manifestjs';
 import env from '@/config/env';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Dialog } from '@headlessui/react';
 import { SignModal } from '@/components/react';

--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -12,7 +12,6 @@ import { Dialog } from '@headlessui/react';
 import { SignModal } from '@/components/react';
 
 interface GroupInfoProps {
-  modalId: string;
   group: ExtendedGroupType | null;
   policyAddress: string;
   address: string;
@@ -22,7 +21,6 @@ interface GroupInfoProps {
 }
 
 export function GroupInfo({
-  modalId,
   group,
   policyAddress,
   address,
@@ -170,7 +168,7 @@ export function GroupInfo({
     <Dialog
       open={showInfoModal}
       onClose={() => setShowInfoModal(false)}
-      className={`modal modal-open fixed flex p-0 m-0`}
+      className={`modal modal-open fixed flex p-0 m-0 z-0`}
       style={{
         height: '100vh',
         width: '100vw',

--- a/components/groups/modals/memberManagementModal.tsx
+++ b/components/groups/modals/memberManagementModal.tsx
@@ -21,7 +21,6 @@ interface ExtendedMember extends MemberSDKType {
 }
 
 interface MemberManagementModalProps {
-  modalId: string;
   members: MemberSDKType[];
   groupId: string;
   groupAdmin: string;
@@ -33,7 +32,6 @@ interface MemberManagementModalProps {
 }
 
 export function MemberManagementModal({
-  modalId,
   members: initialMembers,
   groupId,
   groupAdmin,
@@ -245,7 +243,7 @@ export function MemberManagementModal({
                         setFieldValue(fieldName, selectedAddress);
                       }
                       setIsContactsOpen(false);
-                      (document.getElementById(modalId) as HTMLDialogElement)?.close();
+                      // (document.getElementById(modalId) as HTMLDialogElement)?.close();
                     }}
                     currentAddress={address}
                   />
@@ -315,9 +313,9 @@ export function MemberManagementModal({
                                     aria-label="contacts-btn"
                                     onClick={() => {
                                       handleContactButtonClick(index);
-                                      (
-                                        document.getElementById(modalId) as HTMLDialogElement
-                                      ).close();
+                                      // (
+                                      //   document.getElementById(modalId) as HTMLDialogElement
+                                      // ).close();
                                     }}
                                     className="btn btn-primary btn-xs text-white absolute right-2 top-1"
                                   >

--- a/components/groups/modals/memberManagementModal.tsx
+++ b/components/groups/modals/memberManagementModal.tsx
@@ -243,7 +243,6 @@ export function MemberManagementModal({
                         setFieldValue(fieldName, selectedAddress);
                       }
                       setIsContactsOpen(false);
-                      // (document.getElementById(modalId) as HTMLDialogElement)?.close();
                     }}
                     currentAddress={address}
                   />

--- a/components/groups/modals/memberManagementModal.tsx
+++ b/components/groups/modals/memberManagementModal.tsx
@@ -13,7 +13,7 @@ import { TailwindModal } from '@/components/react/modal';
 import env from '@/config/env';
 import { truncateAddress } from '@/utils';
 import { Dialog } from '@headlessui/react';
-import { SignModal } from '@/components/react';
+import { AddressCopyButton, SignModal } from '@/components/react';
 
 interface ExtendedMember extends MemberSDKType {
   isNew: boolean;
@@ -311,12 +311,7 @@ export function MemberManagementModal({
                                   <button
                                     type="button"
                                     aria-label="contacts-btn"
-                                    onClick={() => {
-                                      handleContactButtonClick(index);
-                                      // (
-                                      //   document.getElementById(modalId) as HTMLDialogElement
-                                      // ).close();
-                                    }}
+                                    onClick={() => handleContactButtonClick(index)}
                                     className="btn btn-primary btn-xs text-white absolute right-2 top-1"
                                   >
                                     <MdContacts className="w-4 h-4" />
@@ -333,23 +328,17 @@ export function MemberManagementModal({
                               </div>
                             )}
                           </Field>
-                          <button
-                            onClick={e => {
-                              e.preventDefault();
-                              navigator.clipboard.writeText(member.address).catch(error => {
-                                console.error('Failed to copy address:', error);
-                              });
-                            }}
-                            className="btn btn-ghost hover:bg-transparent btn-sm ml-2"
-                          >
-                            <CopyIcon className="w-4 h-4" />
-                          </button>
+
+                          <AddressCopyButton
+                            address={member.address}
+                            className="btn btn-ghost hover:bg-transparent btn-sm"
+                          />
                         </div>
                         <div className="w-[10%] flex justify-end">
                           <button
                             type="button"
                             onClick={() => handleMemberToggleDeletion(index)}
-                            className={`btn btn-primary btn-square rounded-[12px] btn-sm `}
+                            className={`btn btn-primary btn-square rounded-[12px] btn-sm`}
                           >
                             <TrashIcon className="text-white w-5 h-5" />
                           </button>

--- a/components/groups/modals/updateGroupModal.tsx
+++ b/components/groups/modals/updateGroupModal.tsx
@@ -11,7 +11,6 @@ import {
 import { cosmos } from '@liftedinit/manifestjs';
 import { Any } from '@liftedinit/manifestjs/dist/codegen/google/protobuf/any';
 import env from '@/config/env';
-import { createPortal } from 'react-dom';
 
 import { isValidManifestAddress, secondsToHumanReadable } from '@/utils/string';
 import { TrashIcon, PlusIcon } from '@/components/icons';
@@ -312,7 +311,7 @@ export function UpdateGroupModal({
     <Dialog
       open={showUpdateModal}
       onClose={() => setShowUpdateModal(false)}
-      className={`modal modal-open fixed flex p-0 m-0`}
+      className={`modal modal-open fixed flex p-0 m-0 z-1`}
       style={{
         height: '100vh',
         width: '100vw',
@@ -363,10 +362,7 @@ export function UpdateGroupModal({
                         break;
                     }
                   }}
-                  address={address}
-                  isContactsOpen={isContactsOpen}
                   setIsContactsOpen={setIsContactsOpen}
-                  activeAuthorIndex={activeAuthorIndex}
                   setActiveAuthorIndex={setActiveAuthorIndex}
                 />
 
@@ -492,17 +488,11 @@ function GroupPolicyFormFields({
 
 function GroupDetailsFormFields({
   dispatch,
-  address,
-  isContactsOpen,
   setIsContactsOpen,
-  activeAuthorIndex,
   setActiveAuthorIndex,
 }: {
   dispatch: ({ field, value }: { field: 'title' | 'authors' | 'description'; value: any }) => void;
-  address: string;
-  isContactsOpen: boolean;
   setIsContactsOpen: (open: boolean) => void;
-  activeAuthorIndex: number | null;
   setActiveAuthorIndex: (index: number | null) => void;
 }) {
   const { values, setFieldValue } = useFormikContext<{

--- a/components/react/addressCopy.tsx
+++ b/components/react/addressCopy.tsx
@@ -3,6 +3,43 @@ import { FiCopy, FiCheck } from 'react-icons/fi';
 import { truncateAddress } from '@/utils';
 import { useContacts } from '@/hooks';
 import { useDelayResetState } from '@/hooks/useDelayResetState';
+import { CopyIcon } from '@/components';
+import { CheckIcon } from '@heroicons/react/24/outline';
+
+export interface AddressCopyButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  address: string;
+  onCopy?: () => void;
+}
+
+export const AddressCopyButton: React.FC<AddressCopyButtonProps> = ({
+  address,
+  onCopy,
+  ...props
+}) => {
+  const [copied, setCopied] = useDelayResetState(false, 2000);
+
+  const handleCopy = async (e: React.SyntheticEvent<any>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      onCopy?.();
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+    }
+  };
+
+  return (
+    <button onClick={handleCopy} {...props}>
+      {copied ? (
+        <CheckIcon data-icon="check" height={16} />
+      ) : (
+        <CopyIcon data-icon="copy" height={16} />
+      )}
+    </button>
+  );
+};
 
 /**
  * Show a truncated address with a copy button, and optionally show the name of the address


### PR DESCRIPTION
Only build it for the row when you click the button(s). This speeds up
performance (and redraws), and reduce the code complexity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated address copy button that provides immediate visual feedback upon copying.
	- Enhanced group management modals for improved user interaction with group information and member details.
- **Refactor**
	- Streamlined modal interactions in group management for clearer and more intuitive display of group information and member details.
- **Style**
	- Adjusted modal layering to enhance the visual presentation and interaction flow within group views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->