### PR TITLE
fix: Remove breaking timeout and unnecessary useCallback

### DIFF
--- a/components/react/modal.tsx
+++ b/components/react/modal.tsx
@@ -180,7 +180,7 @@ export const TailwindModal: React.FC<
    * Helper to handle a metamask extension that doesn't fully register as 'NotExist'
    * in the standard wallet flow. We force set the view to NotExist if we detect the error message.
    */
-  const handleMetamaskErrorCheck = useCallback((wallet: ChainWalletBase) => {
+  const handleMetamaskErrorCheck = (wallet: ChainWalletBase) => {
     if (
       wallet?.walletInfo.name === 'cosmos-extension-metamask' &&
       wallet.message?.includes("Cannot read properties of undefined (reading 'request')")
@@ -197,7 +197,7 @@ export const TailwindModal: React.FC<
     }
 
     return false;
-  }, []);
+  };
 
   /**
    * Connect with a wallet that has 'wallet-connect' mode.
@@ -243,8 +243,6 @@ export const TailwindModal: React.FC<
             setCurrentView(ModalView.Error);
           }
         });
-
-      // Remove the timeout and handle errors through the catch block
     },
     [isMobile, walletRepo]
   );
@@ -310,11 +308,9 @@ export const TailwindModal: React.FC<
       // Step 2: We do a small setTimeout to check for metamask extension error
       // or if the wallet doesn't exist. This ensures the error message has time
       // to populate in the wallet's state after calling `getWallet()`.
-      setTimeout(() => {
-        if (handleMetamaskErrorCheck(wallet)) {
-          return;
-        }
-      }, 1);
+      if (handleMetamaskErrorCheck(wallet)) {
+        return;
+      }
 
       // Step 3: If the wallet is "wallet-connect" style, handle phone vs. desktop flows
       if (wallet?.walletInfo.mode === 'wallet-connect') {
@@ -325,13 +321,7 @@ export const TailwindModal: React.FC<
       // Step 4: Otherwise, handle standard extension or browser-based wallet
       handleStandardWalletFlow(wallet, name);
     },
-    [
-      walletRepo,
-      handleEmailOrSmsIfNeeded,
-      handleMetamaskErrorCheck,
-      handleWalletConnectFlow,
-      handleStandardWalletFlow,
-    ]
+    [walletRepo, handleEmailOrSmsIfNeeded, handleWalletConnectFlow, handleStandardWalletFlow]
   );
 
   /**
@@ -353,12 +343,12 @@ export const TailwindModal: React.FC<
    * Called whenever the user closes the modal.
    * If there's a wallet in "Connecting" state, we want to disconnect it before closing.
    */
-  const onCloseModal = useCallback(() => {
+  const onCloseModal = () => {
     if (qrWallet?.walletStatus === WalletStatus.Connecting) {
       qrWallet.disconnect();
     }
     setOpen(false);
-  }, [setOpen, qrWallet]);
+  };
 
   /**
    * If the user clicks "Back to Wallet List" while a QR code is displayed,

--- a/components/react/modal.tsx
+++ b/components/react/modal.tsx
@@ -308,18 +308,20 @@ export const TailwindModal: React.FC<
       // Step 2: We do a small setTimeout to check for metamask extension error
       // or if the wallet doesn't exist. This ensures the error message has time
       // to populate in the wallet's state after calling `getWallet()`.
-      if (handleMetamaskErrorCheck(wallet)) {
-        return;
-      }
+      setTimeout(() => {
+        if (handleMetamaskErrorCheck(wallet)) {
+          return;
+        }
 
-      // Step 3: If the wallet is "wallet-connect" style, handle phone vs. desktop flows
-      if (wallet?.walletInfo.mode === 'wallet-connect') {
-        handleWalletConnectFlow(wallet, name);
-        return;
-      }
+        // Step 3: If the wallet is "wallet-connect" style, handle phone vs. desktop flows
+        if (wallet?.walletInfo.mode === 'wallet-connect') {
+          handleWalletConnectFlow(wallet, name);
+          return;
+        }
 
-      // Step 4: Otherwise, handle standard extension or browser-based wallet
-      handleStandardWalletFlow(wallet, name);
+        // Step 4: Otherwise, handle standard extension or browser-based wallet
+        handleStandardWalletFlow(wallet, name);
+      }, 0);
     },
     [walletRepo, handleEmailOrSmsIfNeeded, handleWalletConnectFlow, handleStandardWalletFlow]
   );

--- a/components/react/modal.tsx
+++ b/components/react/modal.tsx
@@ -343,12 +343,12 @@ export const TailwindModal: React.FC<
    * Called whenever the user closes the modal.
    * If there's a wallet in "Connecting" state, we want to disconnect it before closing.
    */
-  const onCloseModal = () => {
+  const onCloseModal = useCallback(() => {
     if (qrWallet?.walletStatus === WalletStatus.Connecting) {
       qrWallet.disconnect();
     }
     setOpen(false);
-  };
+  }, [setOpen, qrWallet]);
 
   /**
    * If the user clicks "Back to Wallet List" while a QR code is displayed,


### PR DESCRIPTION
useCallback in this case might trigger unnecessary redraws as the dependencies is empty. Also, the timeout was continuing the flow even on errors, which was obviously not the intended consequence.

Fixes #297


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined modal behaviors during wallet connection interactions, ensuring immediate error handling and faster modal closures for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->