### PR TITLE
chore: add link to help

### DIFF
--- a/components/react/mobileNav.tsx
+++ b/components/react/mobileNav.tsx
@@ -13,6 +13,7 @@ import {
   FactoryIcon,
   GroupsIcon,
   LightIcon,
+  QuestionIcon,
 } from '@/components/icons';
 import env from '@/config/env';
 import { useTheme } from '@/contexts/theme';
@@ -40,7 +41,11 @@ export default function MobileNav() {
     if (drawer) drawer.checked = false;
   };
 
-  const NavItem: React.FC<{ Icon: React.ElementType; href: string }> = ({ Icon, href }) => {
+  const NavItem: React.FC<{ Icon: React.ElementType; href: string; label: string }> = ({
+    Icon,
+    href,
+    label,
+  }) => {
     return (
       <li>
         <Link href={href} legacyBehavior>
@@ -49,7 +54,7 @@ export default function MobileNav() {
             className="flex flex-row justify-start items-center transition-all duration-300 ease-in-out text-primary"
           >
             <Icon className="w-8 h-8" />
-            <span className="text-2xl">{href.slice(1, 12)}</span>
+            <span className="text-2xl">{label}</span>
           </div>
         </Link>
       </li>
@@ -86,26 +91,36 @@ export default function MobileNav() {
               </div>
 
               {/* Updated Theme Toggle */}
-              <label className="swap swap-rotate text-[#00000066] dark:text-[#FFFFFF66] hover:text-primary dark:hover:text-primary transition-all duration-300 ease-in-out">
-                <input
-                  type="checkbox"
-                  className="theme-controller hidden"
-                  value="light"
-                  checked={isDark}
-                  onChange={() => {
-                    setIsDark(!isDark);
-                    toggleTheme();
-                  }}
-                />
-                <DarkIcon className="swap-on fill-current w-9 h-9 duration-300" />
-                <LightIcon className="swap-off fill-current w-9 h-9 duration-300" />
-              </label>
+              <div className="flex flex-row items-center gap-2">
+                <Link
+                  href="https://docs.manifestai.org/"
+                  target="_blank"
+                  className="tooltip tooltip-primary tooltip-top hover:after:delay-1000 hover:before:delay-1000"
+                  data-tip="Help Guide"
+                >
+                  <QuestionIcon className={`w-8 h-8 rounded-xl text-primary`} />
+                </Link>
+                <label className="swap swap-rotate text-primary">
+                  <input
+                    type="checkbox"
+                    className="theme-controller hidden"
+                    value="light"
+                    checked={isDark}
+                    onChange={() => {
+                      setIsDark(!isDark);
+                      toggleTheme();
+                    }}
+                  />
+                  <DarkIcon className="swap-on fill-current w-9 h-9 duration-300" />
+                  <LightIcon className="swap-off fill-current w-9 h-9 duration-300" />
+                </label>
+              </div>
             </div>
             <div className="divider divider-horizon"></div>
-            <NavItem Icon={BankIcon} href="/bank" />
-            <NavItem Icon={GroupsIcon} href="/groups" />
-            {isMember && <NavItem Icon={AdminsIcon} href="/admins" />}
-            <NavItem Icon={FactoryIcon} href="/factory" />
+            <NavItem Icon={BankIcon} href="/bank" label="Bank" />
+            <NavItem Icon={GroupsIcon} href="/groups" label="Groups" />
+            {isMember && <NavItem Icon={AdminsIcon} href="/admins" label="Admin" />}
+            <NavItem Icon={FactoryIcon} href="/factory" label="Factory" />
 
             <div className="divider divider-horizon"></div>
 

--- a/components/react/sideNav.tsx
+++ b/components/react/sideNav.tsx
@@ -12,6 +12,7 @@ import {
   FactoryIcon,
   GroupsIcon,
   LightIcon,
+  QuestionIcon,
 } from '@/components/icons';
 import env from '@/config/env';
 import { useTheme } from '@/contexts/theme';
@@ -117,6 +118,18 @@ export default function SideNav({ isDrawerVisible, setDrawerVisible }: SideNavPr
           <LightIcon className="swap-on fill-current w-9 h-9 duration-300" />
           <DarkIcon className="swap-off fill-current w-9 h-9 duration-300" />
         </label>
+        <div
+          className="tooltip tooltip-top tooltip-primary hover:after:delay-1000 hover:before:delay-1000"
+          data-tip="Help Guide"
+        >
+          <div className="flex justify-center w-full text-[#00000066] dark:text-[#FFFFFF66]">
+            <Link href="https://docs.manifestai.org/" target="_blank">
+              <QuestionIcon
+                className={`w-8 h-8 rounded-xl text-[#00000066] dark:text-[#FFFFFF66] hover:text-primary dark:hover:text-primary transition-all duration-300 ease-in-out`}
+              />
+            </Link>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -233,20 +246,42 @@ export default function SideNav({ isDrawerVisible, setDrawerVisible }: SideNavPr
           </div>
         </ul>
         <div className="flex flex-row justify-between items-center">
-          <Link href="https://github.com/liftedinit/manifest-app" target="_blank">
-            <p className="text-sm text-gray-500">v{version}</p>
-          </Link>
           <div className="flex flex-row justify-between items-center gap-3">
-            <Link href="https://discord.gg/manifestai" target="_blank">
+            <Link href="https://github.com/liftedinit/manifest-app" target="_blank">
+              <p className="text-sm text-gray-500">v{version}</p>
+            </Link>
+            <Link
+              href="https://docs.manifestai.org/"
+              target="_blank"
+              className="tooltip tooltip-primary tooltip-top hover:after:delay-1000 hover:before:delay-1000"
+              data-tip="Help Guide"
+            >
+              <QuestionIcon
+                className={`w-4 h-4 rounded-xl text-black dark:text-white transition-colors duration-300`}
+              />
+            </Link>
+          </div>
+          <div className="flex flex-row justify-between items-center gap-3">
+            <Link
+              href="https://discord.gg/manifestai"
+              target="_blank"
+              className="tooltip tooltip-primary tooltip-top hover:after:delay-1000 hover:before:delay-1000"
+              data-tip="Discord"
+            >
               <Image
                 src={getRealLogo('/discord', theme === 'dark')}
-                alt={'Discord'}
+                alt={'Manifest Discord'}
                 width={12}
                 height={12}
                 className="w-4 h-4 rounded-xl"
               />
             </Link>
-            <Link href="https://x.com/ManifestAIs" target="_blank">
+            <Link
+              href="https://x.com/ManifestAIs"
+              target="_blank"
+              className="tooltip tooltip-primary tooltip-top hover:after:delay-1000 hover:before:delay-1000"
+              data-tip="X"
+            >
               <Image
                 src={getRealLogo('/x', theme === 'dark')}
                 alt={'Twitter'}


### PR DESCRIPTION
This PR adds a menu link to the Alberto help guide.

![2025-02-26_10-59_1](https://github.com/user-attachments/assets/f420d278-5fcd-4ef7-9df2-b86dd94fe858)
![2025-02-26_10-59_2](https://github.com/user-attachments/assets/ca3d71b6-2954-44fc-b2b7-3d3328824694)
![2025-02-26_11-00](https://github.com/user-attachments/assets/446f9722-346e-4847-8bbb-016f3ba81aac)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Navigation items now display clear, descriptive labels for improved usability.
  - A new help guide icon has been added to both the mobile and side navigation areas.
  - The theme toggle layout has been updated for a more consistent experience.

- **Style**
  - Updated tooltips and descriptive text for navigation links, including enhanced accessibility for the Discord link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->