### PR TITLE
refactor: Remove usage of TailwindModal for contacts and use AddressInput

### DIFF
--- a/components/admins/modals/multiMfxBurnModal.tsx
+++ b/components/admins/modals/multiMfxBurnModal.tsx
@@ -4,11 +4,8 @@ import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank
 import { Any } from '@liftedinit/manifestjs/dist/codegen/google/protobuf/any';
 import { Field, FieldArray, FieldProps, Form, Formik } from 'formik';
 import React, { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { MdContacts } from 'react-icons/md';
 
-import { MinusIcon, PlusIcon } from '@/components/icons';
-import { TailwindModal } from '@/components/react';
+import { MinusIcon } from '@/components/icons';
 import { SignModal } from '@/components/react';
 import { NumberInput, TextInput } from '@/components/react/inputs';
 import env from '@/config/env';
@@ -52,7 +49,6 @@ export function MultiBurnModal({ isOpen, onClose, admin, address, denom }: Multi
   const { estimateFee } = useFeeEstimation(env.chain);
   const { burnHeldBalance } = liftedinit.manifest.v1.MessageComposer.withTypeUrl;
   const { submitProposal } = cosmos.group.v1.MessageComposer.withTypeUrl;
-  const [isContactsOpen, setIsContactsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
   const updateBurnPair = (index: number, field: 'address' | 'amount', value: string) => {
@@ -248,20 +244,6 @@ export function MultiBurnModal({ isOpen, onClose, admin, address, denom }: Multi
                     {isSigning ? <span className="loading loading-dots loading-md"></span> : 'Burn'}
                   </button>
                 </div>
-                <TailwindModal
-                  isOpen={isContactsOpen}
-                  setOpen={setIsContactsOpen}
-                  showContacts={true}
-                  currentAddress={address}
-                  onSelect={(selectedAddress: string) => {
-                    if (selectedIndex !== null) {
-                      updateBurnPair(selectedIndex, 'address', selectedAddress);
-                      setFieldValue(`burnPairs.${selectedIndex}.address`, selectedAddress);
-                    }
-                    setIsContactsOpen(false);
-                    setSelectedIndex(null);
-                  }}
-                />
               </Form>
             )}
           </Formik>

--- a/components/admins/modals/multiMfxMintModal.tsx
+++ b/components/admins/modals/multiMfxMintModal.tsx
@@ -4,14 +4,13 @@ import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank
 import { Any } from '@liftedinit/manifestjs/dist/codegen/google/protobuf/any';
 import { MsgPayout } from '@liftedinit/manifestjs/dist/codegen/liftedinit/manifest/v1/tx';
 import { Field, FieldArray, FieldProps, Form, Formik } from 'formik';
-import React, { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useState } from 'react';
 import { MdContacts } from 'react-icons/md';
 
 import { MinusIcon, PlusIcon } from '@/components/icons';
-import { TailwindModal } from '@/components/react';
 import { SignModal } from '@/components/react';
 import { NumberInput, TextInput } from '@/components/react/inputs';
+import { AddressInput } from '@/components/react/inputs/AddressInput';
 import env from '@/config/env';
 import { useFeeEstimation, useTx } from '@/hooks';
 import { parseNumberToBigInt, shiftDigits } from '@/utils';
@@ -55,7 +54,6 @@ export function MultiMintModal({ isOpen, onClose, admin, address, denom }: Multi
   const { estimateFee } = useFeeEstimation(env.chain);
   const { payout } = liftedinit.manifest.v1.MessageComposer.withTypeUrl;
   const { submitProposal } = cosmos.group.v1.MessageComposer.withTypeUrl;
-  const [isContactsOpen, setIsContactsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
   const updatePayoutPair = (index: number, field: 'address' | 'amount', value: string) => {
@@ -180,7 +178,7 @@ export function MultiMintModal({ isOpen, onClose, admin, address, denom }: Multi
                               <Field name={`payoutPairs.${index}.address`}>
                                 {({ field, meta }: FieldProps) => (
                                   <div className="relative">
-                                    <TextInput
+                                    <AddressInput
                                       showError={false}
                                       label="Address"
                                       {...field}
@@ -188,18 +186,6 @@ export function MultiMintModal({ isOpen, onClose, admin, address, denom }: Multi
                                       className={`input input-bordered w-full ${
                                         meta.touched && meta.error ? 'input-error' : ''
                                       }`}
-                                      rightElement={
-                                        <button
-                                          type="button"
-                                          onClick={() => {
-                                            setSelectedIndex(index);
-                                            setIsContactsOpen(true);
-                                          }}
-                                          className="btn btn-primary btn-sm text-white"
-                                        >
-                                          <MdContacts className="w-5 h-5" />
-                                        </button>
-                                      }
                                     />
                                     {meta.touched && meta.error && (
                                       <div
@@ -274,21 +260,6 @@ export function MultiMintModal({ isOpen, onClose, admin, address, denom }: Multi
                     )}
                   </button>
                 </div>
-                <TailwindModal
-                  isOpen={isContactsOpen}
-                  setOpen={setIsContactsOpen}
-                  showContacts={true}
-                  currentAddress={address}
-                  onSelect={(selectedAddress: string) => {
-                    if (selectedIndex !== null) {
-                      // Update both the local state and Formik state
-                      updatePayoutPair(selectedIndex, 'address', selectedAddress);
-                      setFieldValue(`payoutPairs.${selectedIndex}.address`, selectedAddress);
-                    }
-                    setIsContactsOpen(false);
-                    setSelectedIndex(null);
-                  }}
-                />
               </Form>
             )}
           </Formik>

--- a/components/bank/forms/ibcSendForm.tsx
+++ b/components/bank/forms/ibcSendForm.tsx
@@ -13,7 +13,7 @@ import { AmountInput } from '@/components';
 import { DenomDisplay } from '@/components/factory';
 import { SearchIcon } from '@/components/icons';
 import { TextInput } from '@/components/react/inputs';
-import { TailwindModal } from '@/components/react/modal';
+import { AddressInput } from '@/components/react/inputs/AddressInput';
 import env from '@/config/env';
 import { useToast } from '@/contexts';
 import { useSkipClient } from '@/contexts/skipGoContext';
@@ -64,7 +64,6 @@ export default function IbcSendForm({
   const [isSending, setIsSending] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [feeWarning, setFeeWarning] = useState('');
-  const [isContactsOpen, setIsContactsOpen] = useState(false);
 
   // Hooks and context
   const { getOfflineSignerAmino } = useChain(env.chain);
@@ -623,7 +622,7 @@ export default function IbcSendForm({
                   </div>
                 </div>
 
-                <TextInput
+                <AddressInput
                   label="Send To"
                   name="recipient"
                   placeholder="Enter address"
@@ -633,16 +632,6 @@ export default function IbcSendForm({
                   }}
                   className="input-md w-full"
                   style={{ borderRadius: '12px' }}
-                  rightElement={
-                    <button
-                      type="button"
-                      aria-label="contacts-btn"
-                      onClick={() => setIsContactsOpen(true)}
-                      className="btn btn-primary btn-sm text-white"
-                    >
-                      <MdContacts className="w-5 h-5" />
-                    </button>
-                  }
                 />
 
                 <TextInput
@@ -668,15 +657,6 @@ export default function IbcSendForm({
                   {isSending ? <span className="loading loading-dots loading-xs"></span> : 'Send'}
                 </button>
               </div>
-              <TailwindModal
-                isOpen={isContactsOpen}
-                setOpen={setIsContactsOpen}
-                showContacts={true}
-                currentAddress={address}
-                onSelect={(selectedAddress: string) => {
-                  setFieldValue('recipient', selectedAddress);
-                }}
-              />
             </Form>
           );
         }}

--- a/components/bank/forms/sendForm.tsx
+++ b/components/bank/forms/sendForm.tsx
@@ -4,14 +4,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Any } from 'cosmjs-types/google/protobuf/any';
 import { Form, Formik } from 'formik';
 import React, { useMemo, useState } from 'react';
-import { MdContacts } from 'react-icons/md';
 import { PiCaretDownBold } from 'react-icons/pi';
 
 import { AmountInput, MaxButton } from '@/components';
 import { DenomDisplay } from '@/components/factory';
 import { SearchIcon } from '@/components/icons';
 import { TextInput } from '@/components/react/inputs';
-import { TailwindModal } from '@/components/react/modal';
+import { AddressInput } from '@/components/react/inputs/AddressInput';
 import env from '@/config/env';
 import { useFeeEstimation, useTx } from '@/hooks';
 import { parseNumberToBigInt, shiftDigits, truncateString } from '@/utils';
@@ -49,7 +48,6 @@ export default function SendForm({
   const { estimateFee } = useFeeEstimation(env.chain);
   const { send } = cosmos.bank.v1beta1.MessageComposer.withTypeUrl;
   const { submitProposal } = cosmos.group.v1.MessageComposer.withTypeUrl;
-  const [isContactsOpen, setIsContactsOpen] = useState(false);
 
   const filteredBalances = balances?.filter(token => {
     const displayName = token.metadata?.display ?? token.display;
@@ -193,7 +191,7 @@ export default function SendForm({
         validationSchema={validationSchema}
         onSubmit={handleSend}
       >
-        {({ isValid, dirty, setFieldValue, values, errors }) => {
+        {({ isValid, dirty, setFieldValue, values, errors, handleChange }) => {
           // Use direct calculation instead of useMemo
           const selectedTokenBalance = values?.selectedToken
             ? balances?.find(token => token.base === values.selectedToken.base)
@@ -317,26 +315,14 @@ export default function SendForm({
                   </div>
                 </div>
 
-                <TextInput
-                  label="Send To"
+                <AddressInput
                   name="recipient"
+                  label="Send To"
                   placeholder="Enter address"
                   value={values.recipient}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setFieldValue('recipient', e.target.value);
-                  }}
+                  onChange={handleChange}
                   className="input-md w-full"
                   style={{ borderRadius: '12px' }}
-                  rightElement={
-                    <button
-                      type="button"
-                      aria-label="contacts-btn"
-                      onClick={() => setIsContactsOpen(true)}
-                      className="btn btn-primary btn-sm text-white"
-                    >
-                      <MdContacts className="w-5 h-5" />
-                    </button>
-                  }
                 />
                 <TextInput
                   label="Memo (optional)"
@@ -344,9 +330,7 @@ export default function SendForm({
                   placeholder="Memo"
                   style={{ borderRadius: '12px' }}
                   value={values.memo}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setFieldValue('memo', e.target.value);
-                  }}
+                  onChange={handleChange}
                   className="input-md w-full"
                 />
               </div>
@@ -361,15 +345,6 @@ export default function SendForm({
                   {isSending ? <span className="loading loading-dots loading-xs"></span> : 'Send'}
                 </button>
               </div>
-              <TailwindModal
-                isOpen={isContactsOpen}
-                setOpen={setIsContactsOpen}
-                showContacts={true}
-                currentAddress={address}
-                onSelect={(selectedAddress: string) => {
-                  setFieldValue('recipient', selectedAddress);
-                }}
-              />
             </Form>
           );
         }}

--- a/components/factory/forms/BurnForm.tsx
+++ b/components/factory/forms/BurnForm.tsx
@@ -8,7 +8,7 @@ import React, { useMemo, useState } from 'react';
 import { MdContacts } from 'react-icons/md';
 
 import { NumberInput, TextInput } from '@/components/react/inputs';
-import { TailwindModal } from '@/components/react/modal';
+import { AddressInput } from '@/components/react/inputs/AddressInput';
 import env from '@/config/env';
 import { useToast } from '@/contexts';
 import { useFeeEstimation, useTokenFactoryBalance, useTx } from '@/hooks';
@@ -48,7 +48,6 @@ export default function BurnForm({
 
   const [burnPairs, setBurnPairs] = useState<BurnPair[]>([{ address: '', amount: '' }]);
 
-  const [isContactsOpen, setIsContactsOpen] = useState(false);
   const queryClient = useQueryClient();
 
   const { tx, isSigning } = useTx(env.chain);
@@ -286,7 +285,7 @@ export default function BurnForm({
                         )}
                       </div>
                       <div className="flex-grow relative">
-                        <TextInput
+                        <AddressInput
                           showError={false}
                           label="TARGET"
                           name="recipient"
@@ -299,16 +298,6 @@ export default function BurnForm({
                           className={`input input-bordered w-full transition-none ${
                             touched.recipient && errors.recipient ? 'input-error' : ''
                           }`}
-                          rightElement={
-                            <button
-                              type="button"
-                              aria-label="contacts-btn"
-                              onClick={() => setIsContactsOpen(true)}
-                              className="btn btn-primary btn-sm text-white"
-                            >
-                              <MdContacts className="w-5 h-5" />
-                            </button>
-                          }
                         />
                         {touched.recipient && errors.recipient && (
                           <div
@@ -338,16 +327,6 @@ export default function BurnForm({
                         )}
                       </button>
                     </div>
-                    <TailwindModal
-                      isOpen={isContactsOpen}
-                      setOpen={setIsContactsOpen}
-                      showContacts={true}
-                      currentAddress={address}
-                      onSelect={(selectedAddress: string) => {
-                        setRecipient(selectedAddress);
-                        setFieldValue('recipient', selectedAddress);
-                      }}
-                    />
                   </Form>
                 )}
               </Formik>

--- a/components/factory/forms/MintForm.tsx
+++ b/components/factory/forms/MintForm.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import { MdContacts } from 'react-icons/md';
 
 import { NumberInput, TextInput } from '@/components/react/inputs';
-import { TailwindModal } from '@/components/react/modal';
+import { AddressInput } from '@/components/react/inputs/AddressInput';
 import env from '@/config/env';
 import { useFeeEstimation, useTx } from '@/hooks';
 import { ExtendedMetadataSDKType, parseNumberToBigInt, shiftDigits, truncateString } from '@/utils';
@@ -34,7 +34,6 @@ export default function MintForm({
 }>) {
   const [amount, setAmount] = useState('');
   const [recipient, setRecipient] = useState(address || '');
-  const [isContactsOpen, setIsContactsOpen] = useState(false);
   const queryClient = useQueryClient();
   const { tx, isSigning } = useTx(env.chain);
   const { estimateFee } = useFeeEstimation(env.chain);
@@ -179,7 +178,7 @@ export default function MintForm({
                         )}
                       </div>
                       <div className="flex-grow relative">
-                        <TextInput
+                        <AddressInput
                           showError={false}
                           label="RECIPIENT"
                           name="recipient"
@@ -192,16 +191,6 @@ export default function MintForm({
                           className={`input input-bordered w-full transition-none ${
                             touched.recipient && errors.recipient ? 'input-error' : ''
                           }`}
-                          rightElement={
-                            <button
-                              type="button"
-                              aria-label="contacts-btn"
-                              onClick={() => setIsContactsOpen(true)}
-                              className="btn btn-primary btn-sm text-white"
-                            >
-                              <MdContacts className="w-5 h-5" />
-                            </button>
-                          }
                         />
                         {touched.recipient && errors.recipient && (
                           <div
@@ -233,16 +222,6 @@ export default function MintForm({
                         </button>
                       )}
                     </div>
-                    <TailwindModal
-                      isOpen={isContactsOpen}
-                      setOpen={setIsContactsOpen}
-                      showContacts={true}
-                      currentAddress={address}
-                      onSelect={(selectedAddress: string) => {
-                        setRecipient(selectedAddress);
-                        setFieldValue('recipient', selectedAddress);
-                      }}
-                    />
                   </Form>
                 )}
               </Formik>

--- a/components/groups/forms/groups/GroupDetailsForm.tsx
+++ b/components/groups/forms/groups/GroupDetailsForm.tsx
@@ -1,13 +1,13 @@
 import { FieldArray, Form, Formik, useFormikContext } from 'formik';
 import Link from 'next/link';
 import React from 'react';
-import * as Yup from 'yup';
 
 import { PlusIcon, TrashIcon } from '@/components/icons';
 import { TextArea, TextInput } from '@/components/react/inputs';
 import { AddressInput } from '@/components/react/inputs/AddressInput';
 import { Action, FormData } from '@/helpers/formReducer';
 import { isValidManifestAddress } from '@/utils/string';
+import Yup from '@/utils/yupExtensions';
 
 const GroupSchema = Yup.object().shape({
   title: Yup.string()

--- a/components/groups/forms/groups/GroupDetailsForm.tsx
+++ b/components/groups/forms/groups/GroupDetailsForm.tsx
@@ -1,12 +1,11 @@
-import { Form, Formik, useFormikContext } from 'formik';
+import { FieldArray, Form, Formik, useFormikContext } from 'formik';
 import Link from 'next/link';
 import React from 'react';
-import { MdContacts } from 'react-icons/md';
 import * as Yup from 'yup';
 
 import { PlusIcon, TrashIcon } from '@/components/icons';
 import { TextArea, TextInput } from '@/components/react/inputs';
-import { TailwindModal } from '@/components/react/modal';
+import { AddressInput } from '@/components/react/inputs/AddressInput';
 import { Action, FormData } from '@/helpers/formReducer';
 import { isValidManifestAddress } from '@/utils/string';
 
@@ -56,15 +55,11 @@ const GroupSchema = Yup.object().shape({
 function GroupDetailsFormFields({
   dispatch,
   address,
-  isContactsOpen,
-  setIsContactsOpen,
   activeAuthorIndex,
   setActiveAuthorIndex,
 }: Readonly<{
   dispatch: React.Dispatch<Action>;
   address: string;
-  isContactsOpen: boolean;
-  setIsContactsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   activeAuthorIndex: number | null;
   setActiveAuthorIndex: React.Dispatch<React.SetStateAction<number | null>>;
 }>) {
@@ -101,81 +96,54 @@ function GroupDetailsFormFields({
 
       <div className="form-control w-full">
         <div className="max-h-[30vh] overflow-y-auto px-1">
-          {authors.map((author, index) => (
-            <div key={index} className="flex mb-2 items-center">
-              <TextInput
-                label="Author name or address"
-                name={`authors[${index}]`}
-                placeholder="Author name or address"
-                value={author}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const newAuthors = [...values.authors];
-                  newAuthors[index] = e.target.value;
-                  setFieldValue('authors', newAuthors);
-                  updateField('authors', newAuthors);
-                }}
-                className="flex-grow"
-                rightElement={
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setActiveAuthorIndex(index);
-                        setIsContactsOpen(true);
-                      }}
-                      className="btn btn-primary btn-sm text-white"
-                    >
-                      <MdContacts className="w-5 h-5" />
-                    </button>
-                    {/* Only show trash if more than 1 author OR if it's not the first item */}
-                    {values.authors.length > 1 && index !== 0 && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const newAuthors = authors.filter((_, i) => i !== index);
+          <FieldArray
+            name={'authors'}
+            render={arrayHelpers => {
+              return (
+                <>
+                  {authors.map((author, index) => (
+                    <div key={index} className="flex mb-2 items-center">
+                      <AddressInput
+                        label={index == 0 ? 'Author name or address' : undefined}
+                        name={`authors[${index}]`}
+                        placeholder="Author name or address"
+                        value={author}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                          const newAuthors = [...values.authors];
+                          newAuthors[index] = e.target.value;
                           setFieldValue('authors', newAuthors);
                           updateField('authors', newAuthors);
                         }}
-                        className="btn btn-error btn-sm text-white"
-                      >
-                        <TrashIcon className="w-5 h-5" />
-                      </button>
-                    )}
-                  </div>
-                }
-              />
-            </div>
-          ))}
+                        className="flex-grow"
+                        rightElement={
+                          values.authors.length > 1 &&
+                          index !== 0 && (
+                            <button
+                              type="button"
+                              onClick={() => arrayHelpers.remove(index)}
+                              className="btn btn-error btn-sm text-white"
+                            >
+                              <TrashIcon className="w-5 h-5" />
+                            </button>
+                          )
+                        }
+                      />
+                    </div>
+                  ))}
+
+                  <button
+                    type="button"
+                    onClick={() => arrayHelpers.push('')}
+                    className="btn btn-gradient text-white w-full mt-2"
+                  >
+                    <PlusIcon className="mr-2" /> Add Author
+                  </button>
+                </>
+              );
+            }}
+          />
         </div>
-
-        <button
-          type="button"
-          onClick={() => {
-            const newAuthors = [...values.authors, ''];
-            setFieldValue('authors', newAuthors);
-            updateField('authors', newAuthors);
-          }}
-          className="btn btn-gradient text-white w-full mt-2"
-        >
-          <PlusIcon className="mr-2" /> Add Author
-        </button>
       </div>
-
-      <TailwindModal
-        isOpen={isContactsOpen}
-        setOpen={setIsContactsOpen}
-        showContacts={true}
-        currentAddress={address}
-        onSelect={(selectedAddress: string) => {
-          if (activeAuthorIndex !== null) {
-            const newAuthors = [...values.authors];
-            newAuthors[activeAuthorIndex] = selectedAddress;
-            setFieldValue('authors', newAuthors);
-            updateField('authors', newAuthors);
-            setActiveAuthorIndex(null);
-          }
-        }}
-      />
     </Form>
   );
 }
@@ -191,7 +159,6 @@ export default function GroupDetails({
   dispatch: React.Dispatch<Action>;
   address: string;
 }>) {
-  const [isContactsOpen, setIsContactsOpen] = React.useState(false);
   const [activeAuthorIndex, setActiveAuthorIndex] = React.useState<number | null>(null);
 
   const authors = Array.isArray(formData.authors) ? formData.authors : [formData.authors];
@@ -223,8 +190,6 @@ export default function GroupDetails({
                     <GroupDetailsFormFields
                       dispatch={dispatch}
                       address={address}
-                      isContactsOpen={isContactsOpen}
-                      setIsContactsOpen={setIsContactsOpen}
                       activeAuthorIndex={activeAuthorIndex}
                       setActiveAuthorIndex={setActiveAuthorIndex}
                     />

--- a/components/groups/forms/groups/MemberInfoForm.tsx
+++ b/components/groups/forms/groups/MemberInfoForm.tsx
@@ -1,10 +1,9 @@
 import { Field, FieldArray, FieldProps, Form, Formik, useFormikContext } from 'formik';
 import React, { useState } from 'react';
-import { MdContacts } from 'react-icons/md';
 
 import { PlusIcon, TrashIcon } from '@/components/icons';
-import { NumberInput, TextInput } from '@/components/react';
-import { TailwindModal } from '@/components/react/modal';
+import { TextInput } from '@/components/react';
+import { AddressInput } from '@/components/react/inputs/AddressInput';
 import { Action, FormData } from '@/helpers/formReducer';
 import Yup from '@/utils/yupExtensions';
 
@@ -27,20 +26,13 @@ const MemberInfoSchema = Yup.object().shape({
 
 function MemberInfoFormFields({
   dispatch,
-  isContactsOpen,
-  setIsContactsOpen,
-  activeMemberIndex,
-  setActiveMemberIndex,
-  address,
 }: Readonly<{
   dispatch: (action: Action) => void;
-  isContactsOpen: boolean;
-  setIsContactsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   activeMemberIndex: number | null;
   setActiveMemberIndex: React.Dispatch<React.SetStateAction<number | null>>;
   address: string;
 }>) {
-  const { values, isValid, setFieldValue } = useFormikContext<{
+  const { values } = useFormikContext<{
     members: { address: string; name: string }[];
   }>();
 
@@ -61,7 +53,7 @@ function MemberInfoFormFields({
                     <Field name={`members.${index}.address`}>
                       {({ field, meta }: FieldProps) => (
                         <div className="relative">
-                          <TextInput
+                          <AddressInput
                             showError={false}
                             label="Address"
                             {...field}
@@ -70,20 +62,6 @@ function MemberInfoFormFields({
                             className={`input input-bordered w-full ${
                               meta.touched && meta.error ? 'input-error' : ''
                             }`}
-                            rightElement={
-                              <button
-                                type="button"
-                                aria-label="Select contact from address book"
-                                title="Select contact from address book"
-                                onClick={() => {
-                                  setActiveMemberIndex(index);
-                                  setIsContactsOpen(true);
-                                }}
-                                className="btn btn-primary btn-sm text-white"
-                              >
-                                <MdContacts className="w-5 h-5" />
-                              </button>
-                            }
                             onChange={e => {
                               field.onChange(e);
                               dispatch({
@@ -178,25 +156,6 @@ function MemberInfoFormFields({
           )}
         </FieldArray>
       </div>
-
-      <TailwindModal
-        isOpen={isContactsOpen}
-        setOpen={setIsContactsOpen}
-        showContacts={true}
-        currentAddress={address}
-        onSelect={(selectedAddress: string) => {
-          if (activeMemberIndex !== null) {
-            setFieldValue(`members.${activeMemberIndex}.address`, selectedAddress);
-            dispatch({
-              type: 'UPDATE_MEMBER',
-              index: activeMemberIndex,
-              field: 'address',
-              value: selectedAddress,
-            });
-            setActiveMemberIndex(null);
-          }
-        }}
-      />
     </Form>
   );
 }
@@ -215,7 +174,6 @@ export default function MemberInfoForm({
   address: string;
 }>) {
   // Local states needed by the form fields
-  const [isContactsOpen, setIsContactsOpen] = useState(false);
   const [activeMemberIndex, setActiveMemberIndex] = useState<number | null>(null);
 
   return (
@@ -243,8 +201,6 @@ export default function MemberInfoForm({
 
                     <MemberInfoFormFields
                       dispatch={dispatch}
-                      isContactsOpen={isContactsOpen}
-                      setIsContactsOpen={setIsContactsOpen}
                       activeMemberIndex={activeMemberIndex}
                       setActiveMemberIndex={setActiveMemberIndex}
                       address={address}

--- a/components/groups/modals/memberManagementModal.tsx
+++ b/components/groups/modals/memberManagementModal.tsx
@@ -3,14 +3,13 @@ import { cosmos } from '@liftedinit/manifestjs';
 import { MemberSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/group/v1/types';
 import { Any } from '@liftedinit/manifestjs/dist/codegen/google/protobuf/any';
 import { Field, FieldProps, Form, Formik } from 'formik';
-import React, { useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useRef, useState } from 'react';
 import { MdContacts } from 'react-icons/md';
 import * as Yup from 'yup';
 
 import { CopyIcon, TrashIcon } from '@/components/icons';
 import { AddressCopyButton, SignModal } from '@/components/react';
-import { TailwindModal } from '@/components/react/modal';
+import { AddressInput } from '@/components/react/inputs/AddressInput';
 import env from '@/config/env';
 import { useFeeEstimation, useTx } from '@/hooks';
 import { truncateAddress } from '@/utils';
@@ -171,14 +170,6 @@ export function MemberManagementModal({
     }
   };
 
-  const [isContactsOpen, setIsContactsOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
-
-  const handleContactButtonClick = (index: number) => {
-    setActiveIndex(index);
-    setIsContactsOpen(true);
-  };
-
   const submitFormRef = useRef<(() => void) | null>(null);
   const formikRef = useRef<any>(null);
 
@@ -231,22 +222,6 @@ export function MemberManagementModal({
 
             return (
               <>
-                <div className="z-[9999]">
-                  <TailwindModal
-                    isOpen={isContactsOpen}
-                    setOpen={setIsContactsOpen}
-                    showContacts={true}
-                    showMemberManagementModal={true}
-                    onSelect={(selectedAddress: string) => {
-                      if (activeIndex !== null) {
-                        const fieldName = `members.${activeIndex}.address`;
-                        setFieldValue(fieldName, selectedAddress);
-                      }
-                      setIsContactsOpen(false);
-                    }}
-                    currentAddress={address}
-                  />
-                </div>
                 <Form>
                   <div className="flex items-center mb-4 px-4 text-sm text-gray-400">
                     <div className="w-[10%] ml-3">#</div>
@@ -295,27 +270,17 @@ export function MemberManagementModal({
                           <Field name={`members.${index}.address`}>
                             {({ field, meta }: FieldProps) => (
                               <div className="flex-grow relative">
-                                <input
+                                <AddressInput
                                   {...field}
-                                  type="text"
                                   className={`input input-sm focus:outline-none disabled:bg-transparent disabled:border-none bg-transparent input-ghost w-full ${
                                     meta.touched && meta.error ? 'input-error' : ''
                                   }`}
                                   placeholder="manifest1..."
                                   disabled={!member.isNew || member.markedForDeletion}
                                   value={truncateAddress(field.value)}
+                                  small
                                   data-1p-ignore
                                 />
-                                {member.isNew && !member.markedForDeletion && (
-                                  <button
-                                    type="button"
-                                    aria-label="contacts-btn"
-                                    onClick={() => handleContactButtonClick(index)}
-                                    className="btn btn-primary btn-xs text-white absolute right-2 top-1"
-                                  >
-                                    <MdContacts className="w-4 h-4" />
-                                  </button>
-                                )}
                                 {meta.touched && meta.error && (
                                   <div
                                     className="tooltip tooltip-bottom tooltip-open tooltip-primary dark:text-white text-white text-xs mt-1 absolute left-1/2 transform translate-y-7 -translate-x-4 z-50"

--- a/components/react/addressCopy.tsx
+++ b/components/react/addressCopy.tsx
@@ -57,9 +57,10 @@ export const TruncatedAddressWithCopy = ({
   slice = 24,
 }: {
   showName?: boolean;
-  address: string;
+  address: string | null | undefined;
   slice?: number;
 }) => {
+  address = address ?? '';
   const { contacts } = useContacts();
   const [copied, setCopied] = useDelayResetState(false, 2000);
 

--- a/components/react/inputs/AddressInput.tsx
+++ b/components/react/inputs/AddressInput.tsx
@@ -1,0 +1,85 @@
+import { useChain } from '@cosmos-kit/react';
+import { Dialog } from '@headlessui/react';
+import React from 'react';
+import { MdContacts } from 'react-icons/md';
+
+import { Contacts, TextInput } from '@/components';
+import { BaseInputProps } from '@/components/react/inputs/BaseInput';
+
+import env from '../../../config/env';
+
+export interface AddressInputProps extends BaseInputProps {
+  rightElement?: React.ReactNode;
+  name: string;
+  small?: boolean;
+}
+
+export const AddressInput: React.FC<AddressInputProps> = ({
+  value: initialValue,
+  name,
+  onChange,
+  rightElement,
+  disabled,
+  small,
+  ...props
+}) => {
+  const [value, setValue] = React.useState(initialValue);
+  const [showContacts, setShowContacts] = React.useState(false);
+  const { address } = useChain(env.chain);
+
+  return (
+    <>
+      <TextInput
+        onChange={e => {
+          setValue(e.target.value);
+          onChange?.(e);
+        }}
+        name={name}
+        value={value}
+        disabled={disabled}
+        rightElement={
+          <div className="flex gap-2">
+            {!disabled && (
+              <button
+                type="button"
+                onClick={() => setShowContacts(true)}
+                className={`btn btn-primary text-white ${small ? 'btn-xs' : 'btn-sm'}`}
+              >
+                <MdContacts className={small ? 'w-4 h-4' : 'w-5 h-5'} />
+              </button>
+            )}
+            {rightElement}
+          </div>
+        }
+        {...props}
+      />
+
+      {!disabled && showContacts && (
+        <Dialog
+          className={`modal modal-open fixed flex p-0 m-0 z-1`}
+          style={{
+            height: '100vh',
+            width: '100vw',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          onClose={() => setShowContacts(false)}
+          open={showContacts}
+        >
+          <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+          <Dialog.Panel className="modal-box bg-secondary rounded-[24px] p-6">
+            <Contacts
+              onClose={() => setShowContacts(false)}
+              currentAddress={address ?? ''}
+              onSelect={address => {
+                setValue(address);
+                onChange?.({ target: { name, value: address } } as any);
+              }}
+              selectionMode
+            />
+          </Dialog.Panel>
+        </Dialog>
+      )}
+    </>
+  );
+};

--- a/components/react/inputs/BaseInput.tsx
+++ b/components/react/inputs/BaseInput.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { QuestionIcon } from '@/components/icons';
 
-interface BaseInputProps {
+export interface BaseInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   name: string;
   className?: string;
@@ -13,7 +13,7 @@ interface BaseInputProps {
   helperText?: string;
 }
 
-export const BaseInput: React.FC<BaseInputProps & React.InputHTMLAttributes<HTMLInputElement>> = ({
+export const BaseInput: React.FC<BaseInputProps> = ({
   label,
   rightElement,
   leftElement,

--- a/components/react/inputs/index.ts
+++ b/components/react/inputs/index.ts
@@ -1,3 +1,4 @@
+export * from './AddressInput';
 export * from './AmountInput';
 export * from './TextInput';
 export * from './NumberInput';


### PR DESCRIPTION
This should be cosmetic from the user's point of view, but cleans up and should be quicker to render (as TailwindModal is bloated).

The Contacts dialog might be slightly different, can be adjusted for style later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new address input component to provide a more streamlined and direct way to enter addresses.

- **Refactor**
  - Removed the additional contact selection pop-up to simplify forms across token, group, and member management.
  - Enhanced dynamic author field management for group details.
  - Improved address display handling to ensure consistent and robust interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->