### PR TITLE
fix: If the user is not part of the group return to list

### DIFF
--- a/components/groups/components/myGroups.tsx
+++ b/components/groups/components/myGroups.tsx
@@ -4,7 +4,6 @@ import {
   ThresholdDecisionPolicySDKType,
 } from '@liftedinit/manifestjs/dist/codegen/cosmos/group/v1/types';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/router';
 import React, { useEffect, useMemo, useState } from 'react';
 import { PiInfo } from 'react-icons/pi';
@@ -108,7 +107,6 @@ export default React.memo(function YourGroups({
   const [selectedGroupName, setSelectedGroupName] = useState<string>('Untitled Group');
 
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { address } = useChain(env.chain);
 
   const filteredGroups = groups.groups.filter(group => {
@@ -131,9 +129,8 @@ export default React.memo(function YourGroups({
 
   useEffect(() => {
     // Check if there's a policy address in the URL on component mount
-    const policyAddress = searchParams.get('policyAddress');
-
-    if (policyAddress) {
+    const { policyAddress } = router.query;
+    if (policyAddress && typeof policyAddress === 'string') {
       const group = groups.groups.find(g => g.policies?.[0]?.address === policyAddress);
       if (group) {
         let groupName = 'Untitled Group';
@@ -153,7 +150,7 @@ export default React.memo(function YourGroups({
         router.push('/groups', undefined, { shallow: true });
       }
     }
-  }, [searchParams, groups.groups, router]);
+  }, [groups.groups, router]);
 
   useEffect(() => {
     // Scroll to top when a group is selected

--- a/schemas/group.ts
+++ b/schemas/group.ts
@@ -9,13 +9,21 @@ export const MAXIMUM_GROUP_METADATA_JSON_LENGTH = 100_000;
 /**
  * Converts and validates a JSON string as a group metadata object.
  * @param json The JSON string to convert.
+ * @param throws If true, throws an error if the JSON string is invalid or does not match the
+ *               schema, otherwise would return `undefined`.
  * @returns The group metadata object.
  * @throws If the JSON string is invalid or does not match the schema.
  */
-export function metadataFromJson(json: string): GroupMetadata {
+export function metadataFromJson(json: string, throws?: true): GroupMetadata;
+export function metadataFromJson(json: string, throws: false): GroupMetadata | undefined;
+export function metadataFromJson(json: string, throws: boolean = true): GroupMetadata | undefined {
   try {
     return metadataSchema.validateSync(JSON.parse(json));
   } catch (e: any) {
+    if (!throws) {
+      return undefined;
+    }
+
     // If the error is due to duplicate authors, remove duplicates and try again.
     if (e instanceof Yup.ValidationError && e.type === 'array-unique-items') {
       const x = JSON.parse(json);


### PR DESCRIPTION
If the group address is not found in the user's groups, return to the /groups route and set the selected group to null. This happens even when the page is not reloaded.

Fixes #309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved group selection from URL parameters now ensures that if a non-existent group is selected, you are seamlessly redirected back to the groups listing.

- **Refactor**
  - Enhanced the processing of group metadata for more structured handling, resulting in a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->