### PR TITLE
fix: group info backdrop over sidenav

### DIFF
--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -169,7 +169,7 @@ export function GroupInfo({
     <Dialog
       open={showInfoModal}
       onClose={() => setShowInfoModal(false)}
-      className={`modal ${showInfoModal ? 'modal-open' : ''} fixed flex p-0 m-0`}
+      className={`modal modal-open fixed flex p-0 m-0`}
       style={{
         height: '100vh',
         width: '100vw',

--- a/components/groups/modals/groupInfo.tsx
+++ b/components/groups/modals/groupInfo.tsx
@@ -169,7 +169,7 @@ export function GroupInfo({
     <Dialog
       open={showInfoModal}
       onClose={() => setShowInfoModal(false)}
-      className={`modal modal-open fixed flex p-0 m-0 z-0`}
+      className={`modal ${showInfoModal ? 'modal-open' : ''} fixed flex p-0 m-0`}
       style={{
         height: '100vh',
         width: '100vw',
@@ -179,7 +179,7 @@ export function GroupInfo({
     >
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
-      <Dialog.Panel className="modal-box bg-secondary rounded-[24px] max-h-['574px'] max-w-[542px] p-6">
+      <Dialog.Panel className="modal-box mx-auto bg-secondary rounded-[24px] max-h-['574px'] max-w-[542px] p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center space-x-4">
             <ProfileAvatar walletAddress={policyAddress} size={40} />


### PR DESCRIPTION
This PR fixes group info backdrop over sidenav.

Fixes #326 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated modal display behavior to show only when active.
	- Adjusted modal layout for improved centering within its parent container for a better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->