### PR TITLE
fix: invalidate validator queries on proposal execution

### DIFF
--- a/components/groups/modals/voteDetailsModal.tsx
+++ b/components/groups/modals/voteDetailsModal.tsx
@@ -146,6 +146,8 @@ function VoteDetailsModal({
             queryClient.invalidateQueries({ queryKey: ['proposalInfo', policyAddress] });
             queryClient.invalidateQueries({ queryKey: ['groupInfoByAdmin', policyAddress] });
             queryClient.invalidateQueries({ queryKey: ['groupInfoByMember', address] });
+            queryClient.invalidateQueries({ queryKey: ['validators'] });
+            queryClient.invalidateQueries({ queryKey: ['pendingVals'] });
           },
         },
         'vote-details-modal'


### PR DESCRIPTION
This PR invalidates validator-related queries on proposal execution. We need this to properly refresh the validator lists after creating/removing a (pending) validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced data consistency by ensuring that key data is refreshed immediately after executing proposals, leading to more accurate and up-to-date information in the vote details view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->