### PR TITLE
fix: if there is a problem during gas estimation show the right error

### DIFF
--- a/hooks/useTx.tsx
+++ b/hooks/useTx.tsx
@@ -80,8 +80,9 @@ export const useTx = (chainName: string) => {
       let fee = undefined;
       if (options.fee) {
         fee = typeof options.fee === 'function' ? await options.fee() : options.fee;
+      } else {
+        fee = fee ?? (await estimateFee(msgs));
       }
-      fee = fee ?? (await estimateFee(msgs));
 
       if (!fee) {
         setIsSigning(false);


### PR DESCRIPTION
This was undone by #332.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction fee handling so that any fee explicitly provided is honored, with an estimated fee applied only when no custom fee is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->