### PR TITLE
fix: burn form target address & balance display

### DIFF
--- a/components/factory/forms/__tests__/BurnForm.test.tsx
+++ b/components/factory/forms/__tests__/BurnForm.test.tsx
@@ -42,7 +42,7 @@ describe('BurnForm Component', () => {
   test('renders form with correct details', () => {
     renderWithProps();
     expect(screen.getByText('NAME')).toBeInTheDocument();
-    expect(screen.getByText('CIRCULATING SUPPLY')).toBeInTheDocument();
+    expect(screen.getByText('BALANCE')).toBeInTheDocument();
   });
 
   test('renders not affiliated message when not admin and token is mfx', () => {


### PR DESCRIPTION
This PR adjusts the target in the burn form when burning factory tokens from a group. 
Instead of displaying the circulating supply in the burn form we show the wallet or groups current balance so we can see if we are exceeding the amount.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the token burn process for a more consistent experience when initiating burns, including handling for group proposals.
- **Style**
  - Updated the display label from "CIRCULATING SUPPLY" to "BALANCE" for clearer information presentation.
- **Tests**
  - Adjusted test assertions to reflect the updated display label from "CIRCULATING SUPPLY" to "BALANCE".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->