### PR TITLE
chore: better formatting for balances

### DIFF
--- a/components/bank/components/__tests__/historyBox.test.tsx
+++ b/components/bank/components/__tests__/historyBox.test.tsx
@@ -130,11 +130,11 @@ describe('HistoryBox', () => {
         totalPages={2}
       />
     );
-    expect(screen.queryByText('1.00QT TOKEN')).toBeInTheDocument(); // Send
-    expect(screen.queryByText('2.00Q TOKEN')).toBeInTheDocument(); // Receive
-    expect(screen.queryByText('3.00T TOKEN')).toBeInTheDocument(); // Mint
-    expect(screen.queryByText('1.20B TOKEN')).toBeInTheDocument(); // Burn
-    expect(screen.queryByText('5.00M TOKEN')).toBeInTheDocument(); // Payout
+    expect(screen.queryByText('1QT TOKEN')).toBeInTheDocument(); // Send
+    expect(screen.queryByText('2Q TOKEN')).toBeInTheDocument(); // Receive
+    expect(screen.queryByText('3T TOKEN')).toBeInTheDocument(); // Mint
+    expect(screen.queryByText('1.2B TOKEN')).toBeInTheDocument(); // Burn
+    expect(screen.queryByText('5M TOKEN')).toBeInTheDocument(); // Payout
     expect(screen.queryByText('2.1 TOKEN')).toBeInTheDocument(); // Burn held balance
     expect(screen.queryByText('2.3 TOKEN')).toBeInTheDocument(); // Payout
     expect(screen.queryByText('2.4 TOKEN')).toBeInTheDocument(); // Payout

--- a/components/bank/components/__tests__/tokenList.test.tsx
+++ b/components/bank/components/__tests__/tokenList.test.tsx
@@ -62,14 +62,7 @@ describe('TokenList', () => {
 
   test('renders correctly', () => {
     renderWithChainProvider(
-      <TokenList
-        balances={mockBalances}
-        isLoading={false}
-        refetchBalances={jest.fn()}
-        refetchHistory={jest.fn()}
-        address={''}
-        pageSize={1}
-      />
+      <TokenList balances={mockBalances} isLoading={false} address={''} pageSize={1} />
     );
     const token1Row = screen.getByLabelText('utoken1');
     expect(token1Row).toBeInTheDocument();

--- a/components/bank/components/tokenList.tsx
+++ b/components/bank/components/tokenList.tsx
@@ -4,7 +4,7 @@ import { TokenBalance } from '@/components';
 import SendModal from '@/components/bank/modals/sendModal';
 import { DenomDisplay, DenomInfoModal } from '@/components/factory';
 import { QuestionIcon, SendTxIcon } from '@/components/icons';
-import { shiftDigits, truncateString } from '@/utils';
+import { truncateString } from '@/utils';
 import { CombinedBalanceInfo } from '@/utils/types';
 
 interface TokenListProps {
@@ -98,7 +98,10 @@ export const TokenList = React.memo(function TokenList(props: Readonly<TokenList
                   <DenomDisplay metadata={balance.metadata} />
                 </div>
                 <div className="text-center hidden sm:block md:block lg:block xl:block">
-                  <TokenBalance token={balance} />
+                  <TokenBalance
+                    token={balance}
+                    denom={balance.metadata && truncateString(balance.metadata?.display, 12)}
+                  />
                 </div>
                 <div className="flex flex-row gap-2">
                   <div

--- a/components/bank/components/tokenList.tsx
+++ b/components/bank/components/tokenList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
+import { TokenBalance } from '@/components';
 import SendModal from '@/components/bank/modals/sendModal';
 import { DenomDisplay, DenomInfoModal } from '@/components/factory';
 import { QuestionIcon, SendTxIcon } from '@/components/icons';
@@ -96,18 +97,8 @@ export const TokenList = React.memo(function TokenList(props: Readonly<TokenList
                 <div className="flex flex-row gap-4 items-center justify-start">
                   <DenomDisplay metadata={balance.metadata} />
                 </div>
-                <div className="text-center hidden sm:block md:block lg:hidden xl:block">
-                  <p className="font-semibold text-[#161616] dark:text-white">
-                    {Number(
-                      shiftDigits(
-                        balance.amount,
-                        -(balance.metadata?.denom_units[1]?.exponent ?? 6)
-                      )
-                    ).toLocaleString(undefined, {
-                      maximumFractionDigits: balance.metadata?.denom_units[1]?.exponent ?? 6,
-                    })}{' '}
-                    <span>{truncateString(balance.metadata?.display ?? '', 12).toUpperCase()}</span>
-                  </p>
+                <div className="text-center hidden sm:block md:block lg:block xl:block">
+                  <TokenBalance token={balance} />
                 </div>
                 <div className="flex flex-row gap-2">
                   <div

--- a/components/bank/forms/ibcSendForm.tsx
+++ b/components/bank/forms/ibcSendForm.tsx
@@ -8,7 +8,7 @@ import Image from 'next/image';
 import React, { useEffect, useMemo, useState } from 'react';
 import { PiCaretDownBold } from 'react-icons/pi';
 
-import { IbcChain, MaxButton } from '@/components';
+import { IbcChain, MaxButton, TokenBalance } from '@/components';
 import { AmountInput } from '@/components';
 import { DenomDisplay } from '@/components/factory';
 import { SearchIcon } from '@/components/icons';
@@ -536,34 +536,7 @@ export default function IbcSendForm({
                   </div>
                   <div className="text-xs mt-1 flex  justify-between text-[#00000099] dark:text-[#FFFFFF99]">
                     <div className="flex flex-row gap-1">
-                      <span>
-                        Balance:{' '}
-                        {values.selectedToken
-                          ? Number(
-                              shiftDigits(
-                                Number(selectedTokenBalance?.amount ?? values.selectedToken.amount),
-                                -(values.selectedToken.metadata?.denom_units[1]?.exponent ?? 6)
-                              )
-                            ).toLocaleString(undefined, {
-                              maximumFractionDigits:
-                                values.selectedToken.metadata?.denom_units[1]?.exponent ?? 6,
-                            })
-                          : '0'}
-                      </span>
-                      <span>
-                        {(() => {
-                          const tokenDisplayName =
-                            values.selectedToken?.metadata?.display ??
-                            values.selectedToken?.display ??
-                            'Select';
-
-                          return tokenDisplayName.startsWith('factory')
-                            ? tokenDisplayName.split('/').pop()?.toUpperCase()
-                            : tokenDisplayName.startsWith('u')
-                              ? tokenDisplayName.slice(1).toUpperCase()
-                              : truncateString(tokenDisplayName, 10).toUpperCase();
-                        })()}
-                      </span>
+                      Balance: <TokenBalance token={selectedTokenBalance ?? values.selectedToken} />
                       <MaxButton
                         token={values.selectedToken}
                         setTokenAmount={(amount: string) => setFieldValue('amount', amount)}

--- a/components/bank/forms/sendForm.tsx
+++ b/components/bank/forms/sendForm.tsx
@@ -6,7 +6,7 @@ import { Form, Formik } from 'formik';
 import React, { useMemo, useState } from 'react';
 import { PiCaretDownBold } from 'react-icons/pi';
 
-import { AmountInput, MaxButton } from '@/components';
+import { AmountInput, MaxButton, TokenBalance } from '@/components';
 import { DenomDisplay } from '@/components/factory';
 import { SearchIcon } from '@/components/icons';
 import { TextInput } from '@/components/react/inputs';
@@ -14,7 +14,7 @@ import { AddressInput } from '@/components/react/inputs/AddressInput';
 import env from '@/config/env';
 import { useFeeEstimation, useTx } from '@/hooks';
 import { sendForm } from '@/schemas';
-import { parseNumberToBigInt, shiftDigits, truncateString } from '@/utils';
+import { parseNumberToBigInt } from '@/utils';
 import { CombinedBalanceInfo } from '@/utils/types';
 
 export default function SendForm({
@@ -210,38 +210,16 @@ export default function SendForm({
                   </div>
                   <div className="text-xs mt-1 flex justify-between text-[#00000099] dark:text-[#FFFFFF99]">
                     <div className="flex flex-row gap-1 ml-1">
-                      <span>
-                        Balance:{'  '}
-                        {selectedTokenBalance
-                          ? Number(
-                              shiftDigits(
-                                Number(selectedTokenBalance.amount),
-                                -(selectedTokenBalance.metadata?.denom_units[1]?.exponent ?? 6)
-                              )
-                            ).toLocaleString()
-                          : Number(
-                              shiftDigits(
-                                Number(values.selectedToken?.amount ?? 0),
-                                -(values.selectedToken?.metadata?.denom_units[1]?.exponent ?? 6)
-                              )
-                            ).toLocaleString()}
-                      </span>
-                      <span className="">
-                        {values.selectedToken?.metadata?.display?.startsWith('factory')
-                          ? values.selectedToken?.metadata?.display?.split('/').pop()?.toUpperCase()
-                          : truncateString(
-                              values.selectedToken?.metadata?.display ?? '',
-                              10
-                            ).toUpperCase()}
-                      </span>
-
+                      Balance: <TokenBalance token={selectedTokenBalance ?? values.selectedToken} />
                       <MaxButton
                         token={values.selectedToken}
                         setTokenAmount={(amount: string) => setFieldValue('amount', amount)}
                         disabled={isSigning}
                       />
                     </div>
-                    {errors.amount && <div className="text-red-500 text-xs">{errors.amount}</div>}
+                    {errors.amount && (
+                      <div className="text-red-500 text-xs text-right">{errors.amount}</div>
+                    )}
                     {errors.feeWarning && !errors.amount && (
                       <div className="text-yellow-500 text-xs">{errors.feeWarning}</div>
                     )}

--- a/components/factory/components/DenomDisplay.tsx
+++ b/components/factory/components/DenomDisplay.tsx
@@ -13,29 +13,37 @@ export const DenomVerifiedBadge = ({
   return verified ? <VerifiedIcon {...props} /> : <></>;
 };
 
+export interface DenomDisplayProps {
+  denom?: string;
+  metadata?: MetadataSDKType | null;
+  withBackground?: boolean;
+  image?: boolean;
+}
+
 export const DenomDisplay = ({
   denom,
   metadata,
   withBackground,
-}: {
-  metadata?: MetadataSDKType | null;
-  denom?: string;
-  withBackground?: boolean;
-}) => {
+  image = true,
+}: DenomDisplayProps) => {
   const name = formatTokenDisplay(denom ?? metadata?.display ?? '?').toUpperCase();
 
   return (
     <>
-      <div className="flex items-center justify-center">
-        <DenomImage withBackground={withBackground} denom={metadata} />
-      </div>
-      <p className="align-middle font-semibold text-[#161616] dark:text-white">
+      {image && (
+        <div className="flex items-center justify-center">
+          <DenomImage withBackground={withBackground} denom={metadata} />
+        </div>
+      )}
+      <span>
         {name}
-        <DenomVerifiedBadge
-          base={metadata?.base}
-          className="w-4 mx-1 inline relative bottom-1 text-primary"
-        />
-      </p>
+        {metadata?.base && (
+          <DenomVerifiedBadge
+            base={metadata?.base}
+            className="w-4 mx-1 inline relative bottom-1 text-primary"
+          />
+        )}
+      </span>
     </>
   );
 };

--- a/components/react/TokenBalance.tsx
+++ b/components/react/TokenBalance.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { DenomDisplay } from '@/components';
+import { CombinedBalanceInfo, formatLargeNumber, shiftDigits, truncateString } from '@/utils';
+
+export interface TokenBalanceProps {
+  token: CombinedBalanceInfo;
+}
+
+/**
+ * Display the token balance, handling very large amounts of tokens.
+ * @param token
+ * @constructor
+ */
+export const TokenBalance = ({ token }: TokenBalanceProps) => {
+  const units = token.metadata?.denom_units;
+  const denomUnit = units?.[units.length - 1];
+  const exponent = denomUnit?.exponent ?? 6;
+  const denom = (denomUnit?.denom ?? token.display).toUpperCase();
+
+  const balance = formatLargeNumber(Number(shiftDigits(Number(token.amount ?? 0), -exponent)));
+
+  return (
+    <>
+      <span className="inline-block">
+        {balance} <DenomDisplay image={false} denom={denom} />
+      </span>
+    </>
+  );
+};

--- a/components/react/TokenBalance.tsx
+++ b/components/react/TokenBalance.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import React from 'react';
 
 import { DenomDisplay } from '@/components';
@@ -20,13 +21,21 @@ export const TokenBalance = ({ token, denom }: TokenBalanceProps) => {
   const exponent = denomUnit?.exponent ?? 6;
   denom = (denom ?? denomUnit?.denom ?? token.display).toUpperCase();
 
-  const balance = formatLargeNumber(Number(shiftDigits(Number(token.amount ?? 0), -exponent)));
+  const [balance, tooltipAmount] = React.useMemo(() => {
+    const amount = shiftDigits(token.amount ?? 0, -exponent);
+    const amountBN = new BigNumber(amount);
+    const balance = formatLargeNumber(Number(amount));
+
+    const int = BigInt(amountBN.integerValue(BigNumber.ROUND_DOWN).toFixed(0));
+    const dec = amountBN.minus(int.toString()).toNumber();
+    const tooltipAmount = `${int.toLocaleString()}${dec ? ('' + dec).replace(/^0\./, '.') : ''}`;
+
+    return [balance, tooltipAmount];
+  }, [token.amount, exponent]);
 
   return (
-    <>
-      <span className="inline-block">
-        {balance} <DenomDisplay image={false} denom={denom} />
-      </span>
-    </>
+    <span className="inline-block tooltip token-amount" data-tip={tooltipAmount + ' ' + denom}>
+      {balance} <DenomDisplay image={false} denom={denom} />
+    </span>
   );
 };

--- a/components/react/TokenBalance.tsx
+++ b/components/react/TokenBalance.tsx
@@ -5,18 +5,20 @@ import { CombinedBalanceInfo, formatLargeNumber, shiftDigits, truncateString } f
 
 export interface TokenBalanceProps {
   token: CombinedBalanceInfo;
+  denom?: string | null;
 }
 
 /**
  * Display the token balance, handling very large amounts of tokens.
  * @param token
+ * @param denom
  * @constructor
  */
-export const TokenBalance = ({ token }: TokenBalanceProps) => {
+export const TokenBalance = ({ token, denom }: TokenBalanceProps) => {
   const units = token.metadata?.denom_units;
   const denomUnit = units?.[units.length - 1];
   const exponent = denomUnit?.exponent ?? 6;
-  const denom = (denomUnit?.denom ?? token.display).toUpperCase();
+  denom = (denom ?? denomUnit?.denom ?? token.display).toUpperCase();
 
   const balance = formatLargeNumber(Number(shiftDigits(Number(token.amount ?? 0), -exponent)));
 

--- a/components/react/__tests__/TokenBalance.test.tsx
+++ b/components/react/__tests__/TokenBalance.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { TokenBalance } from '@/components';
+import { mockDenomMeta1 } from '@/tests/mock';
+import { unsafeConvertTokenBase } from '@/utils';
+
+describe('TokenBalance', () => {
+  afterEach(cleanup);
+
+  test('should render the token balance', () => {
+    const mockup = render(
+      <TokenBalance
+        token={{
+          amount: '1000000000000000000',
+          metadata: mockDenomMeta1,
+          display: mockDenomMeta1.display,
+          base: unsafeConvertTokenBase(mockDenomMeta1.base),
+        }}
+      />
+    );
+
+    expect(screen.getByText('1T')).toBeInTheDocument();
+    expect(screen.getByText('TOKEN1')).toBeInTheDocument();
+  });
+
+  test('should render the token balance for small amounts', () => {
+    const mockup = render(
+      <TokenBalance
+        token={{
+          amount: '1234567',
+          metadata: mockDenomMeta1,
+          display: mockDenomMeta1.display,
+          base: unsafeConvertTokenBase(mockDenomMeta1.base),
+        }}
+      />
+    );
+
+    expect(screen.getByText('1.234567')).toBeInTheDocument();
+    expect(screen.getByText('TOKEN1')).toBeInTheDocument();
+  });
+});

--- a/components/react/index.ts
+++ b/components/react/index.ts
@@ -5,3 +5,4 @@ export * from './settingsModal';
 export * from './inputs';
 export { SignModal } from './authSignerModal';
 export * from './ModalDialog';
+export * from './TokenBalance';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -158,6 +158,9 @@ module.exports = {
           color: '#FFFFFF',
           textColor: '#FFFFFF',
         },
+        '.token-amount.tooltip:before': {
+          'max-width': 'none',
+        },
       };
       const errorButton = {
         '.btn-error': {

--- a/utils/__tests__/format.test.ts
+++ b/utils/__tests__/format.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatLargeNumber } from '@/utils';
+
+describe('formatLargeNumber', () => {
+  test('should work', () => {
+    expect(formatLargeNumber(1234)).toBe('1,234');
+    expect(formatLargeNumber(12345678)).toBe('12.35M');
+
+    // Small
+    expect(formatLargeNumber(0.001)).toBe('0.001');
+    expect(formatLargeNumber(0.00001)).toBe('0.00001');
+    expect(formatLargeNumber(0.0000123456789)).toBe('0.000012');
+    expect(formatLargeNumber(0.000000123456789)).toBe('0');
+
+    // And large
+    expect(formatLargeNumber(1e15)).toBe('1Q');
+    expect(formatLargeNumber(1e18)).toBe('1QT');
+    expect(formatLargeNumber(1e19)).toBe('10QT');
+    expect(formatLargeNumber(1e20)).toBe('100QT');
+    expect(formatLargeNumber(1.2345678e20)).toBe('123.46QT');
+    expect(formatLargeNumber(1e24)).toBe('1e24');
+    expect(formatLargeNumber(1e60)).toBe('1e60');
+    expect(formatLargeNumber(1.23456789e24)).toBe('1.234568e24');
+  });
+});

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -5,6 +5,11 @@ import { shiftDigits } from '@/utils/maths';
 
 import { denomToAsset } from './ibc';
 
+/**
+ * Format configuration for large numbers
+ * [threshold value, suffix string, maximum fraction digits]
+ * Ordered from largest to smallest threshold
+ */
 const SUFFIXES: [number, string, number][] = [
   [1e24, '_', 0], // Special case. No suffix for >= 1e24, just scientific notation.
   [1e18, 'QT', 2],
@@ -13,8 +18,13 @@ const SUFFIXES: [number, string, number][] = [
   [1e9, 'B', 2],
   [1e6, 'M', 2],
   [0, '', 6],
+  // Cannot be negative.
 ];
 
+/**
+ * Format a large number to a human-readable string.
+ * @param num The number to format.
+ */
 export function formatLargeNumber(num: number): string {
   if (!Number.isFinite(num)) return 'Invalid number';
   if (num <= 0) return '0';

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -22,9 +22,6 @@ export function formatLargeNumber(num: number): string {
   if (num >= SUFFIXES[0][0]) {
     return `${num.toExponential(6).replace(/\.?0*e\+?/, 'e')}`;
   }
-  if (num < SUFFIXES[SUFFIXES.length - 1][0]) {
-    return `${num.toExponential(6).replace(/\.?0*e-?/, 'e-')}`;
-  }
 
   for (const [value, suffix, maximumFractionDigits] of SUFFIXES) {
     if (num >= value) {
@@ -36,7 +33,7 @@ export function formatLargeNumber(num: number): string {
     }
   }
 
-  throw new Error('Unreachable');
+  return num.toLocaleString();
 }
 
 export function formatDenom(denom: string): string {


### PR DESCRIPTION
See the format.test.ts file for examples of input/output of strings.

Added a tooltip so that redacted amounts can be seen fully. It looks like this:

<img width="856" alt="CleanShot 2025-03-04 at 21 43 51@2x" src="https://github.com/user-attachments/assets/18ee2937-7c78-4b24-ae21-fefff5975578" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `TokenBalance` component for displaying token balances across various forms and components.
  - Updated transaction history to show token amounts without unnecessary leading zeros and decimals.

- **Style**
  - Improved error message alignment for better readability.
  - Modified tooltip styling to allow for expanded width.

- **Refactor**
  - Streamlined token denomination and large number formatting for consistent and clearer value displays.
  - Simplified balance display logic in forms by utilizing the `TokenBalance` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->