### PR TITLE
fix: setIsSigning false after isDeliveredCheck

### DIFF
--- a/hooks/useTx.tsx
+++ b/hooks/useTx.tsx
@@ -92,7 +92,6 @@ export const useTx = (chainName: string) => {
       }
 
       const signed = await client.sign(address, msgs, fee, options.memo || '');
-      setIsSigning(false);
 
       setToastMessage({
         type: 'alert-info',


### PR DESCRIPTION
This Pr removes a line from the useTx hook that set isSigning to false after the signing process but before the tx was completed. 

We now disable buttons and keep isSigning === true until the transaction has completed or failed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the transaction signing indicator so it remains active until the process fully completes, ensuring clearer and more accurate feedback on transaction status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->