### PR TITLE
chore: Remove Contacts view from Tailwind Dialog

### DIFF
--- a/components/groups/forms/groups/MemberInfoForm.tsx
+++ b/components/groups/forms/groups/MemberInfoForm.tsx
@@ -42,7 +42,7 @@ function MemberInfoFormFields({
         <FieldArray name="members">
           {({ remove, push }) => (
             <>
-              {values.members.map((member, index) => (
+              {values.members.map((_member, index) => (
                 <div
                   key={index}
                   className="flex relative flex-row bg-base-300 p-4 gap-2 mb-4 rounded-lg items-end"

--- a/components/react/ModalDialog.tsx
+++ b/components/react/ModalDialog.tsx
@@ -15,6 +15,7 @@ export interface ModalDialogProps extends React.PropsWithChildren {
   panelClassName?: string;
   title?: React.ReactNode;
   disabled?: boolean;
+  icon?: React.ComponentType<{ className: string }>;
 }
 
 export interface SigningModalDialogProps extends ModalDialogProps {}
@@ -75,6 +76,7 @@ export const ModalDialog = ({
   style,
   className,
   children,
+  icon: Icon,
 }: ModalDialogProps) => {
   const [opened, setOpened] = React.useState(open);
   if (open && !opened) {
@@ -123,8 +125,9 @@ export const ModalDialog = ({
           <h3
             role="heading"
             aria-label="Title"
-            className="text-xl font-semibold text-[#161616] dark:text-white mb-6"
+            className="flex flex-row gap-2 items-center text-xl font-semibold text-[#161616] dark:text-white mb-6"
           >
+            {Icon ? <Icon className="w-8 h-8 text-primary" /> : undefined}
             {title}
           </h3>
         )}

--- a/components/react/inputs/AddressInput.tsx
+++ b/components/react/inputs/AddressInput.tsx
@@ -33,22 +33,23 @@ export const AddressInput: React.FC<AddressInputProps> = ({
           setValue(e.target.value);
           onChange?.(e);
         }}
+        className="pr-4"
         name={name}
         value={value}
         disabled={disabled}
         rightElement={
-          <div className="">
+          <>
             {!disabled && (
               <button
                 type="button"
                 onClick={() => setShowContacts(true)}
-                className={`btn btn-primary  text-white ${small ? 'btn-xs' : 'btn-sm'}`}
+                className={`btn btn-primary text-white ${small ? 'btn-xs' : 'btn-sm'}`}
               >
                 <MdContacts className={small ? 'w-4 h-4' : 'w-5 h-5'} />
               </button>
             )}
             {rightElement}
-          </div>
+          </>
         }
         {...props}
       />
@@ -57,8 +58,9 @@ export const AddressInput: React.FC<AddressInputProps> = ({
         <ContactsModal
           open={showContacts}
           onClose={() => setShowContacts(false)}
-          onSelect={address => {
-            setValue(address);
+          onSelect={value => {
+            setValue(value);
+            onChange?.({ target: { name, value } } as React.ChangeEvent<HTMLInputElement>);
             setShowContacts(false);
           }}
           address={address}

--- a/components/react/inputs/AddressInput.tsx
+++ b/components/react/inputs/AddressInput.tsx
@@ -1,9 +1,8 @@
 import { useChain } from '@cosmos-kit/react';
-import { Dialog } from '@headlessui/react';
 import React from 'react';
 import { MdContacts } from 'react-icons/md';
 
-import { Contacts, TextInput } from '@/components';
+import { ContactsModal, TextInput } from '@/components';
 import { BaseInputProps } from '@/components/react/inputs/BaseInput';
 
 import env from '../../../config/env';
@@ -55,30 +54,15 @@ export const AddressInput: React.FC<AddressInputProps> = ({
       />
 
       {!disabled && showContacts && (
-        <Dialog
-          className={`modal modal-open fixed flex p-0 m-0 z-999`}
-          style={{
-            height: '100vh',
-            width: '100vw',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-          onClose={() => setShowContacts(false)}
+        <ContactsModal
           open={showContacts}
-        >
-          <div className="fixed inset-0  " aria-hidden="true" />
-          <Dialog.Panel className="modal-box bg-secondary max-w-xl rounded-[24px] p-6">
-            <Contacts
-              onClose={() => setShowContacts(false)}
-              currentAddress={address ?? ''}
-              onSelect={address => {
-                setValue(address);
-                onChange?.({ target: { name, value: address } } as any);
-              }}
-              selectionMode
-            />
-          </Dialog.Panel>
-        </Dialog>
+          onClose={() => setShowContacts(false)}
+          onSelect={address => {
+            setValue(address);
+            setShowContacts(false);
+          }}
+          address={address}
+        />
       )}
     </>
   );

--- a/components/react/inputs/BaseInput.tsx
+++ b/components/react/inputs/BaseInput.tsx
@@ -19,6 +19,7 @@ export const BaseInput: React.FC<BaseInputProps> = ({
   leftElement,
   helperText,
   showError = true,
+  className,
   ...props
 }) => {
   const [field, meta] = useField(props);
@@ -47,13 +48,13 @@ export const BaseInput: React.FC<BaseInputProps> = ({
           className={`dark:text-[#FFFFFF99] text-[#161616] input border-[#00000033] dark:border-[#FFFFFF33] bg-[#E0E0FF0A] dark:bg-[#E0E0FF0A] w-full 
             autofill:bg-[#E0E0FF0A] dark:autofill:bg-[#E0E0FF0A]
             focus:bg-[#E0E0FF0A] dark:focus:bg-[#E0E0FF0A]
-            ${props.className}`}
+            ${className}`}
         />
         {rightElement && (
-          <div className="absolute inset-y-0 right-0 flex items-center pr-3">{rightElement}</div>
+          <div className="absolute inset-y-0 right-0 flex items-center pr-1">{rightElement}</div>
         )}
         {leftElement && (
-          <div className="absolute inset-y-0 left-0 flex items-center pl-3">{leftElement}</div>
+          <div className="absolute inset-y-0 left-0 flex items-center pl-1">{leftElement}</div>
         )}
       </div>
       {meta.touched && meta.error && showError ? (

--- a/components/react/mobileNav.tsx
+++ b/components/react/mobileNav.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { MdContacts } from 'react-icons/md';
 import { RiMenuUnfoldFill } from 'react-icons/ri';
 
+import { ContactsModal } from '@/components';
 import {
   AdminsIcon,
   ArrowRightIcon,
@@ -21,7 +22,6 @@ import { usePoaGetAdmin } from '@/hooks';
 import { useGroupsByAdmin } from '@/hooks';
 
 import { WalletSection } from '../wallet';
-import { TailwindModal } from './modal';
 
 export default function MobileNav() {
   const { address } = useChain(env.chain);
@@ -146,11 +146,11 @@ export default function MobileNav() {
           </ul>
         </div>
       </div>
-      <TailwindModal
-        isOpen={isContactsOpen}
-        setOpen={setContactsOpen}
-        showContacts={true}
-        onSelect={undefined}
+
+      <ContactsModal
+        open={isContactsOpen}
+        onClose={() => setContactsOpen(false)}
+        selectionMode={false}
       />
     </>
   );

--- a/components/react/modal.tsx
+++ b/components/react/modal.tsx
@@ -27,7 +27,6 @@ import { useDeviceDetect } from '@/hooks';
 import {
   Connected,
   Connecting,
-  Contacts,
   EmailInput,
   Error,
   NotExist,
@@ -43,7 +42,6 @@ export enum ModalView {
   Connected,
   Error,
   NotExist,
-  Contacts,
   EmailInput,
   SMSInput,
 }
@@ -69,22 +67,10 @@ const isWalletConnectionError = (message?: string): boolean => {
 
 export const TailwindModal: React.FC<
   WalletModalProps & {
-    showContacts?: boolean;
-    onSelect?: (address: string) => void;
-    currentAddress?: string;
     showMemberManagementModal?: boolean;
     showMessageEditModal?: boolean;
   }
-> = ({
-  isOpen,
-  setOpen,
-  walletRepo,
-  showContacts = false,
-  onSelect,
-  currentAddress,
-  showMemberManagementModal = false,
-  showMessageEditModal = false,
-}) => {
+> = ({ isOpen, setOpen, walletRepo, showMessageEditModal = false }) => {
   const [currentView, setCurrentView] = useState<ModalView>(ModalView.WalletList);
   const [qrWallet, setQRWallet] = useState<ChainWalletBase | undefined>();
   const [selectedWallet, setSelectedWallet] = useState<ChainWalletBase | undefined>();
@@ -99,36 +85,32 @@ export const TailwindModal: React.FC<
 
   useEffect(() => {
     if (isOpen) {
-      if (showContacts) {
-        setCurrentView(ModalView.Contacts);
-      } else {
-        switch (walletStatus) {
-          case WalletStatus.Disconnected:
-            setCurrentView(ModalView.WalletList);
-            break;
-          case WalletStatus.Connecting:
-            if (current?.walletInfo.mode === 'wallet-connect' && !isMobile) {
-              setCurrentView(ModalView.QRCode);
-            } else {
-              setCurrentView(ModalView.Connecting);
-            }
-            break;
-          case WalletStatus.Connected:
-            setCurrentView(ModalView.Connected);
-            break;
-          case WalletStatus.Error:
-            setCurrentView(ModalView.Error);
-            break;
-          case WalletStatus.Rejected:
-            setCurrentView(ModalView.Error);
-            break;
-          case WalletStatus.NotExist:
-            setCurrentView(ModalView.NotExist);
-            break;
-        }
+      switch (walletStatus) {
+        case WalletStatus.Disconnected:
+          setCurrentView(ModalView.WalletList);
+          break;
+        case WalletStatus.Connecting:
+          if (current?.walletInfo.mode === 'wallet-connect' && !isMobile) {
+            setCurrentView(ModalView.QRCode);
+          } else {
+            setCurrentView(ModalView.Connecting);
+          }
+          break;
+        case WalletStatus.Connected:
+          setCurrentView(ModalView.Connected);
+          break;
+        case WalletStatus.Error:
+          setCurrentView(ModalView.Error);
+          break;
+        case WalletStatus.Rejected:
+          setCurrentView(ModalView.Error);
+          break;
+        case WalletStatus.NotExist:
+          setCurrentView(ModalView.NotExist);
+          break;
       }
     }
-  }, [isOpen, walletStatus, currentWalletName, showContacts, current?.walletInfo.mode, isMobile]);
+  }, [isOpen, walletStatus, currentWalletName, current?.walletInfo.mode, isMobile]);
 
   /**
    * Handle the lifecycle for QR Code actions.
@@ -373,7 +355,6 @@ export const TailwindModal: React.FC<
    *  - Connected, Connecting
    *  - QRCode
    *  - Error, NotExist
-   *  - Contacts (an address book / contact list view)
    */
   const _render = useMemo(
     () => {
@@ -495,18 +476,6 @@ export const TailwindModal: React.FC<
             />
           );
 
-        case ModalView.Contacts:
-          return (
-            <Contacts
-              onClose={onCloseModal}
-              onReturn={walletRepo ? () => setCurrentView(ModalView.WalletList) : undefined}
-              selectionMode={Boolean(onSelect)}
-              onSelect={onSelect}
-              currentAddress={currentAddress}
-              showMessageEditModal={showMessageEditModal}
-            />
-          );
-
         default:
           // A fallback if we are syncing or re-connecting
           return (
@@ -529,8 +498,6 @@ export const TailwindModal: React.FC<
       walletRepo,
       currentWalletData,
       current,
-      onSelect,
-      currentAddress,
       showMessageEditModal,
       selectedWallet,
       qrState,
@@ -548,7 +515,7 @@ export const TailwindModal: React.FC<
   return (
     <Portal>
       <Transition.Root show={isOpen}>
-        <Dialog as="div" className="relative z-9999" onClose={onCloseModal}>
+        <Dialog as="div" className="relative z-50" onClose={onCloseModal}>
           <div className="fixed inset-0">
             <Transition.Child
               as={Fragment}

--- a/components/react/sideNav.tsx
+++ b/components/react/sideNav.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { MdContacts } from 'react-icons/md';
 
+import { ContactsModal } from '@/components';
 import {
   AdminsIcon,
   BankIcon,
@@ -22,7 +23,6 @@ import { getRealLogo } from '@/utils';
 
 import packageInfo from '../../package.json';
 import { IconWallet, WalletSection } from '../wallet';
-import { TailwindModal } from './modal';
 
 interface SideNavProps {
   isDrawerVisible: boolean;
@@ -204,7 +204,7 @@ export default function SideNav({ isDrawerVisible, setDrawerVisible }: SideNavPr
           <div className="w-full flex flex-col space-y-2 mb-4">
             <button
               onClick={() => setContactsOpen(true)}
-              className="flex w-full items-center p-2 text-base font-normal rounded-lg text-[#00000066] dark:text-[#FFFFFF66] hover:bg-[#0000000A] hover:text-primary dark:hover:text-primary dark:hover:bg-base-300 transition duration-300 ease-in-out"
+              className="flex w-full items-center p-2 text-base font-normal rounded-lg text-[#00000066] dark:text-[#FFFFFF66] hover:bg-[#0000000A] hover:text-primary dark:hover:text-primary dark:hover:bg-base-300 transition duration-300 ease-in-out cursor-pointer"
             >
               <MdContacts className="w-8 h-8 mr-6" />
               <span className="text-xl">Contacts</span>
@@ -337,11 +337,11 @@ export default function SideNav({ isDrawerVisible, setDrawerVisible }: SideNavPr
           ></path>
         </svg>
       </button>
-      <TailwindModal
-        isOpen={isContactsOpen}
-        setOpen={setContactsOpen}
-        showContacts={true}
-        onSelect={undefined}
+
+      <ContactsModal
+        open={isContactsOpen}
+        onClose={() => setContactsOpen(false)}
+        selectionMode={false}
       />
     </>
   );

--- a/components/react/views/Connected.tsx
+++ b/components/react/views/Connected.tsx
@@ -11,7 +11,7 @@ import { useBalance } from '@/hooks/useQueries';
 import { getRealLogo, shiftDigits, truncateAddress } from '@/utils';
 import ProfileAvatar from '@/utils/identicon';
 
-import { Contacts } from './Contacts';
+import { ContactsModal } from './Contacts';
 
 export const Connected = ({
   onClose,
@@ -42,10 +42,6 @@ export const Connected = ({
       setTimeout(() => setCopied(false), 2000);
     }
   };
-
-  if (showContacts) {
-    return <Contacts onClose={onClose} onReturn={() => setShowContacts(false)} />;
-  }
 
   return (
     <div className="p-2 w-full mx-auto pt-4">
@@ -107,6 +103,13 @@ export const Connected = ({
         >
           <MdContacts className="w-8 h-8 text-primary" />
         </button>
+
+        <ContactsModal
+          className="z-[9999]"
+          open={showContacts}
+          onClose={() => setShowContacts(false)}
+          selectionMode={false}
+        />
       </div>
       <div className="bg-base-300 dark:bg-base-300 rounded-lg py-3 px-2 mb-4">
         <p className="text-sm leading-4 tracking-wider text-gray-500 dark:text-gray-400 mb-1 ml-2">

--- a/components/react/views/Contacts.tsx
+++ b/components/react/views/Contacts.tsx
@@ -2,17 +2,16 @@ import { Dialog } from '@headlessui/react';
 import { ChevronLeftIcon, PencilIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { saveAs } from 'file-saver';
 import { Form, Formik } from 'formik';
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { MdContacts } from 'react-icons/md';
 
+import { ModalDialog, TruncatedAddressWithCopy } from '@/components';
 import { SearchIcon } from '@/components/icons';
 import { TextInput } from '@/components/react/inputs';
 import { useToast } from '@/contexts/toastContext';
 import { useContacts } from '@/hooks/useContacts';
 import { Contact } from '@/utils/types';
 import Yup from '@/utils/yupExtensions';
-
-import { TruncatedAddressWithCopy } from '../addressCopy';
 
 export const Contacts = ({
   onClose,
@@ -139,13 +138,6 @@ export const Contacts = ({
           <Dialog.Title as="h3" className="text-md font-semibold">
             Add Contact
           </Dialog.Title>
-          <button
-            type="button"
-            className="p-2 text-primary bg-neutral rounded-full hover:bg-gray-200 dark:hover:bg-[#00000033]"
-            onClick={onClose}
-          >
-            <XMarkIcon className="w-5 h-5" aria-hidden="true" />
-          </button>
         </div>
         <Formik
           initialValues={{ name: '', address: '' }}
@@ -190,33 +182,6 @@ export const Contacts = ({
   // Main contacts view with search bar and contacts list
   return (
     <div className="p-2 w-full mx-auto pt-4">
-      <div className="flex justify-between items-center -mt-4 mb-6">
-        {onReturn ? (
-          <button
-            type="button"
-            className="p-2 text-primary bg-neutral rounded-full hover:bg-gray-200 dark:hover:bg-[#00000033]"
-            onClick={onReturn}
-          >
-            <ChevronLeftIcon className="w-5 h-5" aria-hidden="true" />
-          </button>
-        ) : (
-          <div className="w-9 h-9" />
-        )}
-        <div className="flex flex-row gap-2 items-center">
-          <MdContacts className="w-8 h-8 text-primary" />
-          <Dialog.Title as="h3" className="text-md font-semibold">
-            {selectionMode ? 'Select Contact' : 'Contacts'}
-          </Dialog.Title>
-        </div>
-        <button
-          type="button"
-          className="p-2 text-primary bg-neutral rounded-full hover:bg-gray-200 dark:hover:bg-[#00000033]"
-          onClick={onClose}
-        >
-          <XMarkIcon className="w-5 h-5" aria-hidden="true" />
-        </button>
-      </div>
-
       {selectionMode && currentAddress && (
         <button
           onClick={() => {
@@ -398,5 +363,41 @@ export const Contacts = ({
         </>
       )}
     </div>
+  );
+};
+
+export interface ContactsModalProps {
+  address?: string;
+  open: boolean;
+  onClose: () => void;
+  onSelect?: (address: string) => void;
+  className?: string;
+  selectionMode?: boolean;
+}
+
+export const ContactsModal = ({
+  open,
+  onClose,
+  onSelect,
+  address,
+  className,
+  selectionMode = true,
+}: ContactsModalProps) => {
+  return (
+    <ModalDialog
+      onClose={onClose}
+      open={open}
+      className={className}
+      panelClassName="max-w-2xl"
+      icon={MdContacts}
+      title={selectionMode ? 'Select Contact' : 'Contacts'}
+    >
+      <Contacts
+        onClose={onClose}
+        currentAddress={address ?? ''}
+        onSelect={address => onSelect?.(address)}
+        selectionMode={selectionMode}
+      />
+    </ModalDialog>
   );
 };

--- a/components/react/views/__tests__/Contacts.test.tsx
+++ b/components/react/views/__tests__/Contacts.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, jest, mock, spyOn, test } from 'bun:test';
+import React from 'react';
+
+import { ContactsModal } from '@/components';
+import { ContactsContext, ContactsContextType } from '@/hooks';
+import { renderWithChainProvider } from '@/tests/render';
+
+const contacts: ContactsContextType = {
+  exportContacts: jest.fn(),
+  importContacts: jest.fn(),
+  updateContact: jest.fn(),
+  contacts: [
+    { name: 'Alice', address: '0x123' },
+    { name: 'Bob', address: '0x456' },
+  ],
+  addContact: jest.fn(),
+  removeContact: jest.fn(),
+};
+
+// TODO: this test suite should not need to mock the router, but somehow it does.
+const m = jest.fn();
+mock.module('next/router', () => ({
+  useRouter: m.mockReturnValue({
+    query: {},
+    push: jest.fn(),
+  }),
+}));
+
+describe('ContactsModal', () => {
+  afterEach(cleanup);
+
+  test('works', () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+
+    const mockup = renderWithChainProvider(
+      <ContactsContext.Provider value={contacts}>
+        <ContactsModal onSelect={onSelect} open onClose={() => {}} />
+      </ContactsContext.Provider>
+    );
+
+    expect(mockup.getByText('Alice')).toBeInTheDocument();
+    expect(mockup.getByText('Bob')).toBeInTheDocument();
+    fireEvent.click(mockup.getByText('Alice'));
+    expect(onSelect).toHaveBeenCalledWith('0x123');
+    expect(onClose).not.toHaveBeenCalledWith();
+  });
+});

--- a/components/react/views/__tests__/Contacts.test.tsx
+++ b/components/react/views/__tests__/Contacts.test.tsx
@@ -36,7 +36,7 @@ describe('ContactsModal', () => {
 
     const mockup = renderWithChainProvider(
       <ContactsContext.Provider value={contacts}>
-        <ContactsModal onSelect={onSelect} open onClose={() => {}} />
+        <ContactsModal onSelect={onSelect} open onClose={onClose} />
       </ContactsContext.Provider>
     );
 
@@ -44,6 +44,6 @@ describe('ContactsModal', () => {
     expect(mockup.getByText('Bob')).toBeInTheDocument();
     fireEvent.click(mockup.getByText('Alice'));
     expect(onSelect).toHaveBeenCalledWith('0x123');
-    expect(onClose).not.toHaveBeenCalledWith();
+    expect(onClose).toHaveBeenCalledWith();
   });
 });

--- a/contexts/manifestAppProviders.tsx
+++ b/contexts/manifestAppProviders.tsx
@@ -110,17 +110,17 @@ export const ManifestAppProviders = ({ children }: { children: ReactNode }) => {
   return (
     <QueryClientProvider client={client}>
       <ReactQueryDevtools />
-      <Web3AuthProvider>
-        <ManifestChainProvider>
-          <SkipProvider>
-            <ThemeProvider>
-              <ToastProvider>
-                <ContactsProvider>{children}</ContactsProvider>
-              </ToastProvider>
-            </ThemeProvider>
-          </SkipProvider>
-        </ManifestChainProvider>
-      </Web3AuthProvider>
+      <ContactsProvider>
+        <Web3AuthProvider>
+          <ManifestChainProvider>
+            <SkipProvider>
+              <ThemeProvider>
+                <ToastProvider>{children}</ToastProvider>
+              </ThemeProvider>
+            </SkipProvider>
+          </ManifestChainProvider>
+        </Web3AuthProvider>
+      </ContactsProvider>
     </QueryClientProvider>
   );
 };

--- a/hooks/__tests__/useContacts.test.tsx
+++ b/hooks/__tests__/useContacts.test.tsx
@@ -1,15 +1,11 @@
-import matchers from '@testing-library/jest-dom/matchers';
-import { cleanup, render, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, jest, test } from 'bun:test';
-import { ErrorBoundary } from 'next/dist/client/components/error-boundary';
-import React, { useContext } from 'react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
+import React from 'react';
 
-import { ContactsContext, ContactsContextType, ContactsProvider, useContacts } from '@/hooks';
-
-expect.extend({ ...matchers });
+import { ContactsProvider, useContacts } from '@/hooks';
 
 function TestComponent() {
-  const { contacts, addContact, removeContact, updateContact } = useContacts();
+  const { contacts, addContact, removeContact } = useContacts();
 
   return (
     <>
@@ -75,10 +71,10 @@ describe('useContacts', () => {
     );
     expect(wrapper.getByTestId('contact-count')).toHaveTextContent('0');
 
-    wrapper.getByTestId('contact-name').value = 'Alice';
-    wrapper.getByTestId('contact-address').value =
+    (wrapper.getByTestId('contact-name') as HTMLInputElement).value = 'Alice';
+    (wrapper.getByTestId('contact-address') as HTMLInputElement).value =
       'manifest1aucdev30u9505dx9t6q5fkcm70sjg4rh7rn5nf';
-    wrapper.getByTestId('contact-add').click();
+    fireEvent.click(wrapper.getByTestId('contact-add'));
 
     wrapper.rerender(
       <ContactsProvider>
@@ -94,8 +90,8 @@ describe('useContacts', () => {
       );
     });
 
-    wrapper.getByTestId('contact-name').value = 'Bob';
-    wrapper.getByTestId('contact-address').value =
+    (wrapper.getByTestId('contact-name') as HTMLInputElement).value = 'Bob';
+    (wrapper.getByTestId('contact-address') as HTMLInputElement).value =
       'manifest1hj5fveer5cjtn4wd6wstzugjfdxzl0xp8ws9ct';
     wrapper.getByTestId('contact-add').click();
 
@@ -110,7 +106,7 @@ describe('useContacts', () => {
 
   test('only allows valid Bech32 addresses', async () => {
     // Disable console.error
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    spyOn(console, 'error');
 
     const wrapper = render(
       <ContactsProvider>
@@ -119,8 +115,8 @@ describe('useContacts', () => {
     );
     expect(wrapper.getByTestId('contact-count')).toHaveTextContent('0');
 
-    wrapper.getByTestId('contact-name').value = 'Alice';
-    wrapper.getByTestId('contact-address').value = 'invalid Bech32';
+    (wrapper.getByTestId('contact-name') as HTMLInputElement).value = 'Alice';
+    (wrapper.getByTestId('contact-address') as HTMLInputElement).value = 'invalid Bech32';
 
     wrapper.getByTestId('contact-add').click();
 
@@ -143,8 +139,8 @@ describe('useContacts', () => {
     );
     expect(wrapper.getByTestId('contact-count')).toHaveTextContent('0');
 
-    wrapper.getByTestId('contact-name').value = 'Alice';
-    wrapper.getByTestId('contact-address').value =
+    (wrapper.getByTestId('contact-name') as HTMLInputElement).value = 'Alice';
+    (wrapper.getByTestId('contact-address') as HTMLInputElement).value =
       'manifest1aucdev30u9505dx9t6q5fkcm70sjg4rh7rn5nf';
     wrapper.getByTestId('contact-add').click();
 
@@ -179,8 +175,8 @@ describe('useContacts', () => {
     );
     expect(wrapper.getByTestId('contact-count')).toHaveTextContent('0');
 
-    wrapper.getByTestId('contact-name').value = 'Alice';
-    wrapper.getByTestId('contact-address').value =
+    (wrapper.getByTestId('contact-name') as HTMLInputElement).value = 'Alice';
+    (wrapper.getByTestId('contact-address') as HTMLInputElement).value =
       'manifest1aucdev30u9505dx9t6q5fkcm70sjg4rh7rn5nf';
     wrapper.getByTestId('contact-add').click();
 
@@ -198,8 +194,8 @@ describe('useContacts', () => {
       );
     });
 
-    wrapper.getByTestId('contact-name').value = 'Not Alice';
-    wrapper.getByTestId('contact-address').value =
+    (wrapper.getByTestId('contact-name') as HTMLInputElement).value = 'Not Alice';
+    (wrapper.getByTestId('contact-address') as HTMLInputElement).value =
       'manifest1aucdev30u9505dx9t6q5fkcm70sjg4rh7rn5nf';
     wrapper.getByTestId('contact-add').click();
 


### PR DESCRIPTION
And into its own component. This ends up also styling the Contact
dialog in line with the other dialogs in the application.

Also, small adjustments to button alignments and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled customizable visual indicators in modal dialogs by allowing optional icons.
	- Introduced a unified contact selection modal, streamlining interactions across address inputs, navigation panels, and connected views.
- **Style**
	- Refined input styling with adjusted padding for a tighter, more responsive layout.
- **Refactor**
	- Modernized modal implementations across various components for consistent behavior.
	- Reordered provider components to enhance context management within the application.
- **Tests**
	- Added a new test suite for the `ContactsModal` component to verify functionality and user interactions.
	- Updated test cases for the `useContacts` hook to improve type safety and standardize event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->