### PR TITLE
fix: reduce group metadata limit

### DIFF
--- a/components/groups/forms/groups/GroupDetailsForm.tsx
+++ b/components/groups/forms/groups/GroupDetailsForm.tsx
@@ -6,6 +6,7 @@ import { PlusIcon, TrashIcon } from '@/components/icons';
 import { TextArea, TextInput } from '@/components/react/inputs';
 import { AddressInput } from '@/components/react/inputs/AddressInput';
 import { Action, FormData } from '@/helpers/formReducer';
+import { MAXIMUM_GROUP_DETAILS_LENGTH } from '@/schemas/group';
 import { isValidManifestAddress } from '@/utils/string';
 import Yup from '@/utils/yupExtensions';
 
@@ -48,7 +49,10 @@ const GroupSchema = Yup.object().shape({
   description: Yup.string()
     .required('Description is required')
     .min(20, 'Description must be at least 20 characters')
-    .max(10000, 'Description must not exceed 10000 characters')
+    .max(
+      MAXIMUM_GROUP_DETAILS_LENGTH,
+      `Description must not exceed ${MAXIMUM_GROUP_DETAILS_LENGTH} characters`
+    )
     .noProfanity('Profanity is not allowed'),
 });
 

--- a/schemas/group.ts
+++ b/schemas/group.ts
@@ -4,7 +4,8 @@ import Yup from '@/utils/yupExtensions';
 /**
  * The maximum length of the group metadata JSON string, in bytes.
  */
-export const MAXIMUM_GROUP_METADATA_JSON_LENGTH = 100_000;
+export const MAXIMUM_GROUP_METADATA_JSON_LENGTH = 2048;
+export const MAXIMUM_GROUP_DETAILS_LENGTH = Math.floor(MAXIMUM_GROUP_METADATA_JSON_LENGTH * 0.6);
 
 /**
  * Converts and validates a JSON string as a group metadata object.
@@ -54,13 +55,16 @@ export const metadataSchema = Yup.object()
     details: Yup.string()
       .required('Details is required')
       .min(20, 'Details must be at least 20 characters')
-      .max(10_000, 'Details must not exceed 10000 characters')
+      .max(
+        MAXIMUM_GROUP_DETAILS_LENGTH,
+        `Details must not exceed ${MAXIMUM_GROUP_DETAILS_LENGTH} characters`
+      )
       .noProfanity(),
     voteOptionContext: Yup.string().optional(),
   })
   .test(
     'metadata-total-length',
-    'Total metadata length must not exceed 100000 characters',
+    `Total metadata length must not exceed ${MAXIMUM_GROUP_DETAILS_LENGTH} characters`,
     function (values) {
       return JSON.stringify(values).length <= MAXIMUM_GROUP_METADATA_JSON_LENGTH;
     }

--- a/schemas/group.ts
+++ b/schemas/group.ts
@@ -64,7 +64,7 @@ export const metadataSchema = Yup.object()
   })
   .test(
     'metadata-total-length',
-    `Total metadata length must not exceed ${MAXIMUM_GROUP_DETAILS_LENGTH} characters`,
+    `Total metadata length must not exceed ${MAXIMUM_GROUP_METADATA_JSON_LENGTH} characters`,
     function (values) {
       return JSON.stringify(values).length <= MAXIMUM_GROUP_METADATA_JSON_LENGTH;
     }


### PR DESCRIPTION
This PR reduces the group metadata limits. It is now limited to 2KB total, 60% of which can be assigned to the group description. The rest is shared between the group title and authors.

2KB should be enough for everyone.

Relates https://github.com/liftedinit/manifest-ledger/releases/tag/v1.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated group description and metadata validations to enforce dynamic character limits.
  - Error messages now display the current maximum length restrictions.
  - Reduced the allowed size for group metadata, ensuring more accurate and consistent input feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->