### PR TITLE
chore: move dialogs into <td>

### DIFF
--- a/components/groups/components/myGroups.tsx
+++ b/components/groups/components/myGroups.tsx
@@ -643,41 +643,41 @@ const GroupRow = React.memo(function GroupRow({
               </button>
             </div>
           </div>
+
+          {showInfo && (
+            <GroupInfo
+              group={group}
+              address={address ?? ''}
+              policyAddress={group.policies[0]?.address ?? ''}
+              onUpdate={() => refetch()}
+              showInfoModal={showInfo}
+              setShowInfoModal={show => setShowInfo(show)}
+            />
+          )}
+
+          {showMembers && (
+            <MemberManagementModal
+              members={group.members.map(member => ({
+                ...member.member,
+                address: member?.member?.address || '',
+                weight: member?.member?.weight || '0',
+                metadata: member?.member?.metadata || '',
+                added_at: member?.member?.added_at || new Date(),
+                isCoreMember: true,
+                isActive: true,
+                isAdmin: member?.member?.address === group.admin,
+                isPolicyAdmin: member?.member?.address === group.policies[0]?.admin,
+              }))}
+              groupId={group.id.toString()}
+              groupAdmin={group.admin}
+              policyAddress={group.policies[0]?.address ?? ''}
+              address={address ?? ''}
+              onUpdate={() => refetch()}
+              setShowMemberManagementModal={show => setShowMembers(show)}
+              showMemberManagementModal={showMembers}
+            />
+          )}
         </td>
-
-        {showInfo && (
-          <GroupInfo
-            group={group}
-            address={address ?? ''}
-            policyAddress={group.policies[0]?.address ?? ''}
-            onUpdate={() => refetch()}
-            showInfoModal={showInfo}
-            setShowInfoModal={show => setShowInfo(show)}
-          />
-        )}
-
-        {showMembers && (
-          <MemberManagementModal
-            members={group.members.map(member => ({
-              ...member.member,
-              address: member?.member?.address || '',
-              weight: member?.member?.weight || '0',
-              metadata: member?.member?.metadata || '',
-              added_at: member?.member?.added_at || new Date(),
-              isCoreMember: true,
-              isActive: true,
-              isAdmin: member?.member?.address === group.admin,
-              isPolicyAdmin: member?.member?.address === group.policies[0]?.admin,
-            }))}
-            groupId={group.id.toString()}
-            groupAdmin={group.admin}
-            policyAddress={group.policies[0]?.address ?? ''}
-            address={address ?? ''}
-            onUpdate={() => refetch()}
-            setShowMemberManagementModal={show => setShowMembers(show)}
-            showMemberManagementModal={showMembers}
-          />
-        )}
       </tr>
     </>
   );


### PR DESCRIPTION
The DOM (and React) does not like having them in <tr> or <tbody>.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Fine-tuned the layout of the group display interface to improve code organization without changing user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->