### PR TITLE
fix: show the simulation error message instead of a generic error

### DIFF
--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -6,6 +6,9 @@ import { useState } from 'react';
 import env from '@/config/env';
 import { useTx } from '@/hooks/useTx';
 
+/**
+ * A custom hook that provides functionality to simulate the creation of a denomination.
+ */
 export const useSimulateDenomCreation = () => {
   const [isSimulating, setIsSimulating] = useState(false);
   const { tx } = useTx(env.chain);
@@ -26,7 +29,11 @@ export const useSimulateDenomCreation = () => {
     });
 
     try {
-      const result = await tx([msg], { simulate: true, returnError: true });
+      const result = await tx([msg], {
+        simulate: true,
+        returnError: true,
+        showToastOnErrors: false,
+      });
 
       if (result === undefined) {
         console.error('Simulation result is undefined');
@@ -34,14 +41,10 @@ export const useSimulateDenomCreation = () => {
       }
 
       if ('error' in result) {
-        console.error('Simulation error:', result.error);
-        return false;
+        throw result.error;
       }
 
-      return true;
-    } catch (error) {
-      console.error('Unexpected error during simulation:', error);
-      return false;
+      return result.success;
     } finally {
       setIsSimulating(false);
     }


### PR DESCRIPTION
Also, performs the sync checks (e.g. profanity) locally before simulating the denom creation. Saves a request to the server.

Fixes #373

The new error when the user hasn't been on the blockchain yet:
![CleanShot 2025-03-17 at 14 32 12@2x](https://github.com/user-attachments/assets/c0cb0541-0366-4106-bbd0-98c0c852cb69)

The new error when the user tries to create an already existing token:
![CleanShot 2025-03-17 at 14 36 06@2x](https://github.com/user-attachments/assets/47e7e919-f148-4be1-92ad-1be8daa4a6b5)
