### PR TITLE
chore: Move pagination of group proposals to its own components

### DIFF
--- a/components/react/Pagination.tsx
+++ b/components/react/Pagination.tsx
@@ -1,0 +1,172 @@
+import React, { createContext } from 'react';
+
+export interface PaginationProps<T> {
+  pageSize: number;
+  defaultPage?: number;
+  selectedPage?: number;
+  dataset: T[];
+
+  onChange?: (data: T[], page: number) => void;
+  children?: React.ReactNode | ((data: T[], page: number) => React.ReactNode);
+}
+
+/**
+ * Creates an array of page indices based on the total number of items, page
+ * size, current page, and maximum number of visible pages. The array may
+ * include the string '...' to represent skipped page ranges.
+ *
+ * @param total - The total number of items across all pages.
+ * @param pageSize - The number of items per page.
+ * @param [current=0] - The current page index (zero-based). Default is 0.
+ * @param [max=8] - The maximum number of visible page indices. Default is 8.
+ * @return An array of page indices (zero-based) and/or '...' to represent
+ *         skipped pages.
+ */
+export function createArrayOfPageIndex(
+  total: number,
+  pageSize: number,
+  current = 0,
+  max = 8
+): (number | '...')[] {
+  if (max <= 4) {
+    throw new Error('max cannot be less than 5');
+  }
+  const nbPages = Math.ceil(total / pageSize);
+  current = Math.max(Math.min(nbPages - 1, current), 0);
+
+  const toShow = Math.min(nbPages, max);
+  if (nbPages <= max) {
+    return [...Array(nbPages).keys()];
+  } else if (current <= toShow / 2) {
+    return [...Array(toShow - 2).keys(), '...', nbPages - 1];
+  } else if (current >= nbPages - 1 - toShow / 2) {
+    return [
+      0,
+      '...',
+      ...Array(toShow - 2)
+        .keys()
+        .map(x => x + nbPages - toShow / 2 - 2), // -2 to account for 0, and last.
+    ];
+  } else {
+    let start = current - Math.floor(toShow / 2 - 1) + 1;
+    let end = current + toShow / 2 - 1;
+    return [
+      0,
+      '...',
+      ...Array(end - start)
+        .keys()
+        .map(x => x + start),
+      '...',
+      nbPages - 1,
+    ];
+  }
+}
+
+export function Pagination<T>({
+  pageSize,
+  defaultPage = 0,
+  selectedPage,
+  dataset,
+  onChange,
+  children,
+}: PaginationProps<T>) {
+  const [pageInner, setPageInner] = React.useState(defaultPage);
+  const pages = createArrayOfPageIndex(dataset.length, pageSize, pageInner);
+  const nbPages: number = Math.ceil(dataset.length / pageSize);
+
+  React.useEffect(() => {
+    if (selectedPage !== undefined) {
+      setPageInner(selectedPage);
+    }
+  }, [selectedPage]);
+
+  function callOnChange() {
+    onChange?.(dataset.slice(pageInner * pageSize, (pageInner + 1) * pageSize), pageInner);
+  }
+
+  function previous() {
+    setPageInner(page => Math.max(0, page - 1));
+    callOnChange();
+  }
+
+  function next() {
+    setPageInner(page => Math.min(nbPages - 1, page + 1));
+    callOnChange();
+  }
+
+  function setPage(page: number) {
+    setPageInner(page);
+    callOnChange();
+  }
+
+  const data = dataset.slice(pageInner * pageSize, (pageInner + 1) * pageSize);
+
+  return (
+    <>
+      {children instanceof Function ? (
+        children(data, pageInner)
+      ) : (
+        <Pagination.Index.Provider value={pageInner}>
+          <Pagination.Data.Provider value={data}>{children}</Pagination.Data.Provider>
+        </Pagination.Index.Provider>
+      )}
+
+      <div className="flex items-center justify-end gap-2 mt-4">
+        <button
+          onClick={previous}
+          disabled={pageInner == 0}
+          aria-label="Previous page"
+          className="p-2 hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          ‹
+        </button>
+
+        {pages.map((p, i) => {
+          if (p === '...') {
+            return (
+              <span key={`ellipsis-${i}`} className="text-black dark:text-white">
+                ...
+              </span>
+            );
+          } else if (p === pageInner) {
+            return (
+              <button
+                key={`page-${p}`}
+                aria-label={`Page ${p}`}
+                aria-current="page"
+                className="w-8 h-8 flex items-center justify-center rounded-lg transition-colors bg-[#0000001A] dark:bg-[#FFFFFF1A] text-black dark:text-white"
+              >
+                {p + 1}
+              </button>
+            );
+          } else {
+            return (
+              <button
+                key={`page-${p}`}
+                onClick={() => setPage(p)}
+                aria-label={`Page ${p}`}
+                className="w-8 h-8 flex items-center justify-center rounded-lg transition-colors hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white"
+              >
+                {p + 1}
+              </button>
+            );
+          }
+        })}
+
+        <button
+          onClick={next}
+          disabled={pageInner === nbPages - 1}
+          aria-label="Next page"
+          className="p-2 hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          ›
+        </button>
+      </div>
+    </>
+  );
+}
+
+Pagination.Index = createContext<number>(-1);
+// Unfortunately, we cannot set the type of the context for Data to T, as T is
+// unknown here.
+Pagination.Data = createContext<any[]>([]);

--- a/components/react/__tests__/Pagination.test.tsx
+++ b/components/react/__tests__/Pagination.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'bun:test';
+import { useContext } from 'react';
+
+import { Pagination, createArrayOfPageIndex } from '@/components/react/Pagination';
+import { formatComponent } from '@/tests';
+
+describe('createArrayOfPageIndex', () => {
+  test('works for small current', () => {
+    expect(createArrayOfPageIndex(10, 2)).toEqual([0, 1, 2, 3, 4]);
+    expect(createArrayOfPageIndex(10, 4)).toEqual([0, 1, 2]);
+  });
+
+  test('ellipsis works', () => {
+    expect(createArrayOfPageIndex(20, 2, 0)).toEqual([0, 1, 2, 3, 4, 5, '...', 9]);
+    expect(createArrayOfPageIndex(20, 2, 10)).toEqual([0, '...', 4, 5, 6, 7, 8, 9]);
+    expect(createArrayOfPageIndex(40, 2, 8)).toEqual([0, '...', 6, 7, 8, 9, 10, '...', 19]);
+    expect(createArrayOfPageIndex(40, 2, 9)).toEqual([0, '...', 7, 8, 9, 10, 11, '...', 19]);
+  });
+});
+
+describe('Pagination', () => {
+  test('works for small dataset', () => {
+    function PageContent() {
+      const i = useContext(Pagination.Index);
+      const d = useContext(Pagination.Data);
+      return (
+        <>
+          {i} {d.join()}
+        </>
+      );
+    }
+
+    const mockup = render(
+      <Pagination pageSize={5} dataset={['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']}>
+        <Pagination.Index.Consumer>{i => i}</Pagination.Index.Consumer>
+        <Pagination.Data.Consumer>{d => JSON.stringify(d)}</Pagination.Data.Consumer>
+      </Pagination>
+    );
+
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('start');
+    fireEvent.click(screen.getByLabelText(/Next page/i));
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('middle');
+    fireEvent.click(screen.getByLabelText(/Next page/i));
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('end');
+  });
+});

--- a/components/react/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/components/react/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -1,0 +1,126 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination works for small dataset: start 1`] = `
+"<DocumentFragment>
+  0["a","b","c","d","e"]
+  <div
+    class="flex items-center justify-end gap-2 mt-4"
+  >
+    <button
+      aria-label="Previous page"
+      class="p-2 hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      disabled=""
+    >
+      ‹
+    </button>
+    <button
+      aria-current="page"
+      aria-label="Page 0"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors bg-[#0000001A] dark:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      1
+    </button>
+    <button
+      aria-label="Page 1"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      2
+    </button>
+    <button
+      aria-label="Page 2"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      3
+    </button>
+    <button
+      aria-label="Next page"
+      class="p-2 hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      ›
+    </button>
+  </div>
+</DocumentFragment>"
+`;
+
+exports[`Pagination works for small dataset: middle 1`] = `
+"<DocumentFragment>
+  1["f","g","h","i","j"]
+  <div
+    class="flex items-center justify-end gap-2 mt-4"
+  >
+    <button
+      aria-label="Previous page"
+      class="p-2 hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      ‹
+    </button>
+    <button
+      aria-label="Page 0"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      1
+    </button>
+    <button
+      aria-current="page"
+      aria-label="Page 1"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors bg-[#0000001A] dark:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      2
+    </button>
+    <button
+      aria-label="Page 2"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      3
+    </button>
+    <button
+      aria-label="Next page"
+      class="p-2 hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      ›
+    </button>
+  </div>
+</DocumentFragment>"
+`;
+
+exports[`Pagination works for small dataset: end 1`] = `
+"<DocumentFragment>
+  2["k"]
+  <div
+    class="flex items-center justify-end gap-2 mt-4"
+  >
+    <button
+      aria-label="Previous page"
+      class="p-2 hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      ‹
+    </button>
+    <button
+      aria-label="Page 0"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      1
+    </button>
+    <button
+      aria-label="Page 1"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      2
+    </button>
+    <button
+      aria-current="page"
+      aria-label="Page 2"
+      class="w-8 h-8 flex items-center justify-center rounded-lg transition-colors bg-[#0000001A] dark:bg-[#FFFFFF1A] text-black dark:text-white"
+    >
+      3
+    </button>
+    <button
+      aria-label="Next page"
+      class="p-2 hover:bg-[#0000001A] dark:hover:bg-[#FFFFFF1A] text-black dark:text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      disabled=""
+    >
+      ›
+    </button>
+  </div>
+</DocumentFragment>"
+`;


### PR DESCRIPTION
This <Pagination> component will be reused in all other page places in the app after this PR is merged.

This is what it looks like with a lot of pages:

![CleanShot 2025-03-19 at 11 09 15@2x](https://github.com/user-attachments/assets/3d007413-52dd-46e1-8327-9d9a3f6bbc8d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a paginated view for proposals, enabling users to navigate through multiple pages effortlessly.
  - Enhanced the proposal display with clear loading indicators, error messages, and messages for when no proposals are available.
  - Added a dedicated table layout to showcase proposals with human-readable time information.

- **Refactor**
  - Streamlined the proposal display process by centralizing proposal filtering and presentation, simplifying the overall user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->