### PR TITLE
chalabi/skip web3auth

### DIFF
--- a/components/bank/forms/ibcSendForm.tsx
+++ b/components/bank/forms/ibcSendForm.tsx
@@ -17,6 +17,7 @@ function IbcSendForm({ token }: { token: string }) {
   const ibcDenom = getIbcDenom(env.chainId, token);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const { getOfflineSignerAmino } = useChain(env.chain);
   // Determine if dark mode is active
   const isDark = theme === 'dark';
 
@@ -141,7 +142,7 @@ function IbcSendForm({ token }: { token: string }) {
       )
     )
     .map(asset => asset.base);
-
+  console.log();
   return (
     <div
       aria-label="ibc-send-form"
@@ -176,6 +177,7 @@ function IbcSendForm({ token }: { token: string }) {
           }}
           brandColor={'#a087ff'}
           onlyTestnet={true}
+          getCosmosSigner={(chainID: string) => Promise.resolve(getOfflineSignerAmino())}
           connectedAddresses={{
             [env.chainId]: address,
           }}

--- a/components/bank/forms/ibcSendForm.tsx
+++ b/components/bank/forms/ibcSendForm.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { OfflineAminoSigner } from '@cosmjs/amino';
+import { StdSignDoc } from '@cosmjs/amino';
 import { OfflineDirectSigner } from '@cosmjs/proto-signing';
 import { useChain } from '@cosmos-kit/react';
 import { Widget } from '@skip-go/widget';
+import { useQueryClient } from '@tanstack/react-query';
 import { assets as axelarAssets } from 'chain-registry/testnet/axelartestnet';
 import { assets as osmosisAssets } from 'chain-registry/testnet/osmosistestnet';
+import { SignDoc } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
 import { useContext, useEffect, useRef } from 'react';
 import { ShadowScopeConfigProvider } from 'react-shadow-scope';
 
@@ -19,7 +22,7 @@ function IbcSendForm({ token }: { token: string }) {
   const { address, getSigningStargateClient } = useChain(env.chain);
   const ibcDenom = getIbcDenom(env.chainId, token);
   const containerRef = useRef<HTMLDivElement>(null);
-
+  const queryClient = useQueryClient();
   const { setIsSigning } = useContext(Web3AuthContext);
 
   async function getCosmosSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
@@ -27,14 +30,14 @@ function IbcSendForm({ token }: { token: string }) {
     if (!('signer' in client)) {
       throw new Error('No cosmos stargate client.');
     }
-    const signer: any = (client as any).signer;
+    const signer: OfflineAminoSigner | OfflineDirectSigner = (client as any).signer;
 
     // Find out which type of signer we have from the Stargate client,
     // then declare the right sign function which also set isSigning.
     if ('signAmino' in signer) {
       return {
         getAccounts: signer.getAccounts.bind(signer),
-        signAmino: async (address: string, doc: any) => {
+        signAmino: async (address: string, doc: StdSignDoc) => {
           setIsSigning(true);
 
           try {
@@ -47,7 +50,7 @@ function IbcSendForm({ token }: { token: string }) {
     } else if ('signDirect' in signer) {
       return {
         getAccounts: signer.getAccounts.bind(signer),
-        signDirect: async (address: string, doc: any) => {
+        signDirect: async (address: string, doc: SignDoc) => {
           setIsSigning(true);
 
           try {
@@ -224,6 +227,11 @@ function IbcSendForm({ token }: { token: string }) {
           getCosmosSigner={getCosmosSigner}
           connectedAddresses={{
             [env.chainId]: address,
+          }}
+          onTransactionComplete={() => {
+            queryClient.invalidateQueries({ queryKey: ['balances'] });
+            queryClient.invalidateQueries({ queryKey: ['balances-resolved'] });
+            queryClient.invalidateQueries({ queryKey: ['getMessagesForAddress'] });
           }}
           theme={themeColors}
         />


### PR DESCRIPTION
- **add offline signer for skip widget**
- **wip**
- **query invalidation**
Allows a user connected too web3auth wallets and ledger (extension) to sign skip widget messages.

This does not allow web3auth or ledger to connect to multiple chains at once as they are currently limited to one



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction signing experience with real-time status updates, ensuring a smoother process.
  - Automatic UI refresh upon transaction completion to display updated account and transaction details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->