### PR TITLE
chore: disable skip widget shadow dom

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,6 @@
         "react-icons": "^5.5.0",
         "react-intersection-observer": "^9.16.0",
         "react-scroll": "^1.9.3",
-        "react-shadow-scope": "1.0.10",
         "react-string-format": "^1.2.0",
         "react-syntax-highlighter": "^15.6.1",
         "sharp": "^0.33.5",

--- a/components/bank/forms/ibcSendForm.tsx
+++ b/components/bank/forms/ibcSendForm.tsx
@@ -196,46 +196,45 @@ function IbcSendForm({ token }: { token: string }) {
       ref={containerRef}
       className="w-[100%] max-w-[500px] px-2 box-border relative"
     >
-      <ShadowScopeConfigProvider config={{ dsd: 'off' }}>
-        <Widget
-          filter={{
-            source: {
-              [env.chainId]: undefined,
-              [env.osmosisChainId]: [...manifestAssetsOnOsmosis, 'uosmo'],
-              [env.axelarChainId]: [...manifestAssetsOnAxelar, 'uaxl'],
-            },
-            destination: {
-              [env.chainId]: undefined,
-              [env.osmosisChainId]: [...manifestAssetsOnOsmosis, 'uosmo'],
-              [env.axelarChainId]: [...manifestAssetsOnAxelar, 'uaxl'],
-            },
-          }}
-          defaultRoute={{
-            srcAssetDenom: token,
-            srcChainId: env.chainId,
-            destChainId: env.osmosisChainId,
-            destAssetDenom: ibcDenom,
-            amountIn: 1,
-            amountOut: 1,
-          }}
-          routeConfig={{
-            allowUnsafe: true,
-            allowSwaps: true,
-          }}
-          brandColor={'#a087ff'}
-          onlyTestnet={true}
-          getCosmosSigner={getCosmosSigner}
-          connectedAddresses={{
-            [env.chainId]: address,
-          }}
-          onTransactionComplete={() => {
-            queryClient.invalidateQueries({ queryKey: ['balances'] });
-            queryClient.invalidateQueries({ queryKey: ['balances-resolved'] });
-            queryClient.invalidateQueries({ queryKey: ['getMessagesForAddress'] });
-          }}
-          theme={themeColors}
-        />
-      </ShadowScopeConfigProvider>
+      <Widget
+        filter={{
+          source: {
+            [env.chainId]: undefined,
+            [env.osmosisChainId]: [...manifestAssetsOnOsmosis, 'uosmo'],
+            [env.axelarChainId]: [...manifestAssetsOnAxelar, 'uaxl'],
+          },
+          destination: {
+            [env.chainId]: undefined,
+            [env.osmosisChainId]: [...manifestAssetsOnOsmosis, 'uosmo'],
+            [env.axelarChainId]: [...manifestAssetsOnAxelar, 'uaxl'],
+          },
+        }}
+        defaultRoute={{
+          srcAssetDenom: token,
+          srcChainId: env.chainId,
+          destChainId: env.osmosisChainId,
+          destAssetDenom: ibcDenom,
+          amountIn: 1,
+          amountOut: 1,
+        }}
+        routeConfig={{
+          allowUnsafe: true,
+          allowSwaps: true,
+        }}
+        brandColor={'#a087ff'}
+        onlyTestnet={true}
+        getCosmosSigner={getCosmosSigner}
+        connectedAddresses={{
+          [env.chainId]: address,
+        }}
+        onTransactionComplete={() => {
+          queryClient.invalidateQueries({ queryKey: ['balances'] });
+          queryClient.invalidateQueries({ queryKey: ['balances-resolved'] });
+          queryClient.invalidateQueries({ queryKey: ['getMessagesForAddress'] });
+        }}
+        theme={themeColors}
+        disableShadowDom={true}
+      />
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^9.16.0",
     "react-scroll": "^1.9.3",
-    "react-shadow-scope": "1.0.10",
     "react-string-format": "^1.2.0",
     "react-syntax-highlighter": "^15.6.1",
     "sharp": "^0.33.5",


### PR DESCRIPTION
This PR disables the SkipGo Widget shadow DOM and removes the `react-shadow-scope` package.

SkipGo Widget manual address input now works.