### PR TITLE
fix: skip only list testnet on testnet

### DIFF
--- a/components/bank/forms/ibcSendForm.tsx
+++ b/components/bank/forms/ibcSendForm.tsx
@@ -172,20 +172,20 @@ function IbcSendForm({ token }: { token: string }) {
     },
   };
 
-  // filter osmosis tokens that are on manifesttestnet
+  // filter osmosis tokens that are on manifest chain
   const manifestAssetsOnOsmosis = osmosisAssets.assets
     .filter(asset =>
       asset?.traces?.some(
-        trace => trace.type === 'ibc' && trace.counterparty.chain_name === 'manifesttestnet'
+        trace => trace.type === 'ibc' && trace.counterparty.chain_name === env.chain
       )
     )
     .map(asset => asset.base);
 
-  // filter axelar tokens that are on manifesttestnet
+  // filter axelar tokens that are on manifest chain
   const manifestAssetsOnAxelar = axelarAssets.assets
     .filter(asset =>
       asset?.traces?.some(
-        trace => trace.type === 'ibc' && trace.counterparty.chain_name === 'manifesttestnet'
+        trace => trace.type === 'ibc' && trace.counterparty.chain_name === env.chain
       )
     )
     .map(asset => asset.base);

--- a/components/bank/forms/ibcSendForm.tsx
+++ b/components/bank/forms/ibcSendForm.tsx
@@ -223,7 +223,7 @@ function IbcSendForm({ token }: { token: string }) {
             allowSwaps: true,
           }}
           brandColor={'#a087ff'}
-          onlyTestnet={true}
+          onlyTestnet={env.chainTier !== 'mainnet'}
           getCosmosSigner={getCosmosSigner}
           connectedAddresses={{
             [env.chainId]: address,


### PR DESCRIPTION
This PR fixes the `onlyTestnet` Skip widget parameter to `true` for chain tiers other than `mainnet`. This PR also filters the asset for the current manifest chain as defined by the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The widget now dynamically adjusts its mode based on the current network environment, ensuring that testnet features activate only when not on the main network.
  - Enhanced asset filtering logic to be environment-specific, improving flexibility in asset selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->