### PR TITLE
chore: set the session duration to 1 month

### DIFF
--- a/contexts/manifestAppProviders.tsx
+++ b/contexts/manifestAppProviders.tsx
@@ -83,6 +83,7 @@ const ManifestChainProvider = ({ children }: { children: ReactNode }) => {
       wallets={combinedWallets}
       logLevel={env.production ? 'NONE' : 'INFO'}
       endpointOptions={endpointOptions}
+      sessionOptions={{ duration: 60 * 60 * 24 }} // 1 day
       walletConnectOptions={{
         signClient: {
           projectId: env.walletConnectKey,

--- a/contexts/manifestAppProviders.tsx
+++ b/contexts/manifestAppProviders.tsx
@@ -83,7 +83,7 @@ const ManifestChainProvider = ({ children }: { children: ReactNode }) => {
       wallets={combinedWallets}
       logLevel={env.production ? 'NONE' : 'INFO'}
       endpointOptions={endpointOptions}
-      sessionOptions={{ duration: 60 * 60 * 24 }} // 1 day
+      sessionOptions={{ duration: 60 * 60 * 24 * 30 }} // 1 month
       walletConnectOptions={{
         signClient: {
           projectId: env.walletConnectKey,


### PR DESCRIPTION
This PR sets the wallet session duration to 1 month. After this period, the wallet will auto-disconnect and the user must reconnect.

Confirmed by  @ebravick.

Related #384 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced enhanced session management, ensuring user sessions now remain active for one month for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->