### PR TITLE
feat: add timeago timestamps to history and refactor some DOM

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "tailwind-scrollbar-hide": "2.0.0",
         "tailwindcss": "4.0.17",
         "three": "0.174.0",
-        "timeago.js": "^4.0.2",
+        "timeago.js": "4.0.2",
         "yup": "1.6.1",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "tailwind-scrollbar-hide": "2.0.0",
         "tailwindcss": "4.0.17",
         "three": "0.174.0",
+        "timeago.js": "^4.0.2",
         "yup": "1.6.1",
       },
       "devDependencies": {
@@ -2887,6 +2888,8 @@
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
     "through2": ["through2@0.6.5", "", { "dependencies": { "readable-stream": ">=1.0.33-1 <1.1.0-0", "xtend": ">=4.0.0 <4.1.0-0" } }, "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg=="],
+
+    "timeago.js": ["timeago.js@4.0.2", "", {}, "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w=="],
 
     "timed-out": ["timed-out@4.0.1", "", {}, "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA=="],
 

--- a/components/bank/components/historyBox.tsx
+++ b/components/bank/components/historyBox.tsx
@@ -145,9 +145,10 @@ export function HistoryBox({
                 {getTransactionIcon(tx, address)}
               </div>
               <div>
-                <p className="text-sm text-[#00000099] dark:text-[#FFFFFF99]">
-                  <TimeAgo datetime={tx.timestamp} />
-                </p>
+                <TimeAgo
+                  datetime={tx.timestamp}
+                  className="text-sm text-[#00000099] dark:text-[#FFFFFF99]"
+                />
                 <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 mt-1">
                   <span className="font-semibold text-[#161616] dark:text-white">
                     {getTransactionMessage(tx, address, metadatas?.metadatas)}

--- a/components/bank/components/historyBox.tsx
+++ b/components/bank/components/historyBox.tsx
@@ -1,6 +1,7 @@
 import { MetadataSDKType } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank/v1beta1/bank';
 import React, { useState } from 'react';
 
+import { TimeAgo } from '@/components';
 import { getHandler } from '@/components/bank/handlers/handlerRegistry';
 import { Navigator, Pagination } from '@/components/react/Pagination';
 import { useTokenFactoryDenomsMetadata } from '@/hooks';
@@ -122,62 +123,57 @@ export function HistoryBox({
   }
 
   return (
-    <div
-      className="w-full mx-auto  h-full flex flex-col  overflow-x-hidden"
-      data-testid="historyBox"
-    >
-      <div className="flex-1 overflow-hidden h-full">
-        <div className="h-full w-full overflow-y-auto space-y-2">
-          {sendTxs?.slice(0, skeletonTxCount).map((tx, index) => (
-            <div
-              key={`${tx.id}-${index}`}
-              className={`flex flex-col sm:flex-row items-start sm:items-center justify-between p-4 
+    <div data-testid="historyBox">
+      <div className="h-full w-full space-y-2">
+        {sendTxs?.slice(0, skeletonTxCount).map((tx, index) => (
+          <div
+            key={`${tx.id}-${index}`}
+            className={`flex flex-col sm:flex-row items-start sm:items-center justify-between p-4 
                     ${
                       tx.error
                         ? 'bg-[#E5393522] dark:bg-[#E5393533] hover:bg-[#E5393544] dark:hover:bg-[#E5393555]'
                         : 'bg-[#FFFFFFCC] dark:bg-[#FFFFFF0F] hover:bg-[#FFFFFF66] dark:hover:bg-[#FFFFFF1A]'
                     }
                     rounded-[16px] cursor-pointer transition-colors`}
-              onClick={() => {
-                setSelectedTx(tx);
-                (document?.getElementById('tx_modal_info') as HTMLDialogElement)?.showModal();
-              }}
-            >
-              <div className="flex flex-row items-center space-x-3 mb-2 sm:mb-0">
-                <div className="w-8 h-8 rounded-full flex items-center justify-center text-[#161616] dark:text-white">
-                  {getTransactionIcon(tx, address)}
+            onClick={() => {
+              setSelectedTx(tx);
+              (document?.getElementById('tx_modal_info') as HTMLDialogElement)?.showModal();
+            }}
+          >
+            <div className="flex flex-row items-center space-x-3 mb-2 sm:mb-0">
+              <div className="w-8 h-8 rounded-full flex items-center justify-center text-[#161616] dark:text-white">
+                {getTransactionIcon(tx, address)}
+              </div>
+              <div>
+                <p className="text-sm text-[#00000099] dark:text-[#FFFFFF99]">
+                  <TimeAgo datetime={tx.timestamp} />
+                </p>
+                <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 mt-1">
+                  <span className="font-semibold text-[#161616] dark:text-white">
+                    {getTransactionMessage(tx, address, metadatas?.metadatas)}
+                  </span>
                 </div>
-                <div>
-                  <p className="text-sm text-[#00000099] dark:text-[#FFFFFF99]">
-                    {formatDateShort(tx.timestamp)}
-                  </p>
-                  <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 mt-1">
-                    <span className="font-semibold text-[#161616] dark:text-white">
-                      {getTransactionMessage(tx, address, metadatas?.metadatas)}
-                    </span>
-                  </div>
-                  {tx.message_index < 10000 ? (
-                    tx.sender === address ? (
-                      <div className="text-gray-500 text-xs mt-1">
-                        Incl.:{' '}
-                        {tx.fee && (
-                          <>
-                            {formatLargeNumber(Number(shiftDigits(tx.fee.amount?.[0]?.amount, -6)))}{' '}
-                            {formatDenomWithBadge(tx.fee.amount?.[0]?.denom, true)} fee
-                          </>
-                        )}
-                      </div>
-                    ) : null
-                  ) : (
+                {tx.message_index < 10000 ? (
+                  tx.sender === address ? (
                     <div className="text-gray-500 text-xs mt-1">
-                      Fee incl. in proposal #{tx.proposal_ids} execution
+                      Incl.:{' '}
+                      {tx.fee && (
+                        <>
+                          {formatLargeNumber(Number(shiftDigits(tx.fee.amount?.[0]?.amount, -6)))}{' '}
+                          {formatDenomWithBadge(tx.fee.amount?.[0]?.denom, true)} fee
+                        </>
+                      )}
                     </div>
-                  )}
-                </div>
+                  ) : null
+                ) : (
+                  <div className="text-gray-500 text-xs mt-1">
+                    Fee incl. in proposal #{tx.proposal_ids} execution
+                  </div>
+                )}
               </div>
             </div>
-          ))}
-        </div>
+          </div>
+        ))}
       </div>
 
       <Navigator

--- a/components/groups/components/Proposals.tsx
+++ b/components/groups/components/Proposals.tsx
@@ -13,6 +13,7 @@ import {
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 
+import { TimeAgo, TimeAgoMode } from '@/components';
 import VoteDetailsModal from '@/components/groups/modals/voteDetailsModal';
 import { Pagination } from '@/components/react/Pagination';
 import { ExtendedGroupType, useMultipleTallyCounts, useProposalsByPolicyAccount } from '@/hooks';
@@ -199,35 +200,6 @@ function ProposalTable({ group, pageSize, proposals }: ProposalTableProps) {
   );
 }
 
-/**
- * Converts a number of seconds into a human-readable duration string relative to the current time.
- * The result is formatted as days, hours, minutes, or less than a minute based on the time difference.
- *
- * @param diff - A number of seconds to transform into human readable time.
- * @return A string representing the remaining duration in human-readable format
- *         (e.g., "2 days", "1 hour", "15 minutes", or "less than a minute").
- */
-export function humanReadableDuration(diff: number) {
-  const secsPerMinute = 60;
-  const secsPerHour = secsPerMinute * 60;
-  const secsPerDay = secsPerHour * 24;
-
-  if (diff <= 0) {
-    return 'none';
-  } else if (diff >= secsPerDay) {
-    const days = Math.floor(diff / secsPerDay);
-    return `${days} day${days === 1 ? '' : 's'}`;
-  } else if (diff >= secsPerHour) {
-    const hours = Math.floor(diff / secsPerHour);
-    return `${hours} hour${hours === 1 ? '' : 's'}`;
-  } else if (diff >= secsPerMinute) {
-    const minutes = Math.floor(diff / secsPerMinute);
-    return `${minutes} minute${minutes === 1 ? '' : 's'}`;
-  } else {
-    return 'less than a minute';
-  }
-}
-
 const ProposalRow = ({
   group,
   proposal,
@@ -307,7 +279,7 @@ const ProposalRow = ({
           {proposal.title}
         </td>
         <td className="bg-secondary group-hover:bg-base-300 px-4 py-4 w-[25%] hidden xl:table-cell">
-          {humanReadableDuration((endTime.getTime() - Date.now()) / 1000)}
+          <TimeAgo datetime={endTime} mode={TimeAgoMode.FutureOnly} />
         </td>
         <td className="bg-secondary group-hover:bg-base-300 px-4 py-4 w-[25%] sm:table-cell md:hidden hidden xl:table-cell ">
           {proposal.messages.length > 0

--- a/components/groups/components/__tests__/Proposals.test.tsx
+++ b/components/groups/components/__tests__/Proposals.test.tsx
@@ -1,7 +1,7 @@
 import { TallyResultSDKType } from '@liftedinit/manifestjs/src/codegen/cosmos/gov/v1/gov';
 import { describe, expect, test } from 'bun:test';
 
-import { humanReadableDuration, isProposalPassing } from '@/components';
+import { isProposalPassing } from '@/components';
 
 describe('isProposalPassing', () => {
   test('works with a passing vote', () => {
@@ -95,35 +95,5 @@ describe('isProposalPassing', () => {
     expect(results.abstainCount).toBe(2n);
     expect(results.isThresholdReached).toBe(true);
     expect(results.isTie).toBe(true);
-  });
-});
-
-describe('humanReadableDuration', () => {
-  test('handles duration less than a minute', () => {
-    expect(humanReadableDuration(45)).toBe('less than a minute');
-    expect(humanReadableDuration(1)).toBe('less than a minute');
-  });
-
-  test('handles minutes', () => {
-    expect(humanReadableDuration(60)).toBe('1 minute');
-    expect(humanReadableDuration(160)).toBe('2 minutes');
-    expect(humanReadableDuration(239)).toBe('3 minutes');
-  });
-
-  test('handles hours', () => {
-    expect(humanReadableDuration(3661)).toBe('1 hour');
-    expect(humanReadableDuration(3600)).toBe('1 hour');
-    expect(humanReadableDuration(3600 * 2 + 1000)).toBe('2 hours');
-    expect(humanReadableDuration(3600 * 2 + 3599)).toBe('2 hours');
-  });
-
-  test('handles large durations', () => {
-    expect(humanReadableDuration(90061)).toBe('1 day');
-    expect(humanReadableDuration(10090061)).toBe('116 days');
-  });
-
-  test('handles done', () => {
-    const result = humanReadableDuration(0); // 0 seconds
-    expect(result).toBe('none');
   });
 });

--- a/components/react/TimeAgo.tsx
+++ b/components/react/TimeAgo.tsx
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from 'react';
+import { format } from 'timeago.js';
+import { Opts, TDate } from 'timeago.js';
+
+/**
+ * Mode of operation for the <TimeAgo /> component.
+ */
+export enum TimeAgoMode {
+  Default = 0,
+  AgoOnly = 1,
+  FutureOnly = 2,
+}
+
+/**
+ * Properties for the TimeAgo component.
+ *
+ * Inherits `relativeDate` and `minInterval` from `timeago.js`.
+ */
+export interface TimeAgoProps extends Opts {
+  /**
+   * The date to convert.
+   */
+  readonly datetime: TDate;
+
+  /**
+   * Whether to live update the component. This is true by default.
+   */
+  readonly live?: boolean;
+
+  /**
+   * Mode of operation for the component.
+   */
+  readonly mode?: TimeAgoMode;
+
+  /**
+   * Show a tooltip with the full time in it. True by default.
+   */
+  readonly tooltip?: boolean;
+}
+
+export const TimeAgo = ({
+  relativeDate,
+  minInterval,
+  datetime,
+  live = true,
+  mode = TimeAgoMode.Default,
+  tooltip = true,
+}: TimeAgoProps) => {
+  const toString = useCallback(() => {
+    const d = new Date(datetime);
+    const now = relativeDate ? new Date(relativeDate) : new Date();
+
+    if (mode === TimeAgoMode.AgoOnly) {
+      if (d.getTime() > now.getTime()) {
+        return 'None';
+      }
+    } else if (mode === TimeAgoMode.FutureOnly) {
+      if (d.getTime() < now.getTime()) {
+        return 'None';
+      }
+    }
+    return format(d, undefined, { relativeDate, minInterval });
+  }, [datetime, minInterval, mode, relativeDate]);
+
+  const [time, setTime] = useState<string>(toString());
+
+  useEffect(() => {
+    if (live) {
+      const id = setInterval(() => setTime(toString()), 60000);
+      return () => clearInterval(id);
+    }
+  }, [datetime, relativeDate, minInterval, mode, live, toString]);
+
+  const d = new Date(datetime);
+  const localeOpts: Partial<Intl.DateTimeFormatOptions> = {
+    dateStyle: 'long',
+    timeStyle: 'long',
+  };
+
+  const props = {
+    ...(tooltip
+      ? {
+          className: 'tooltip tooltip-info tooltip-top',
+          'data-tip': d.toLocaleString(undefined, localeOpts),
+        }
+      : undefined),
+  };
+
+  return (
+    <time {...props} dateTime={d.toISOString()}>
+      {time}
+    </time>
+  );
+};

--- a/components/react/TimeAgo.tsx
+++ b/components/react/TimeAgo.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { format } from 'timeago.js';
-import { Opts, TDate } from 'timeago.js';
+import React, { useCallback, useEffect, useState } from 'react';
+import { TDate, format } from 'timeago.js';
 
 /**
  * Mode of operation for the <TimeAgo /> component.
@@ -16,7 +15,7 @@ export enum TimeAgoMode {
  *
  * Inherits `relativeDate` and `minInterval` from `timeago.js`.
  */
-export interface TimeAgoProps extends Opts {
+export interface TimeAgoProps extends React.HTMLProps<HTMLTimeElement> {
   /**
    * The date to convert.
    */
@@ -36,15 +35,20 @@ export interface TimeAgoProps extends Opts {
    * Show a tooltip with the full time in it. True by default.
    */
   readonly tooltip?: boolean;
+
+  /**
+   * The relative date.
+   */
+  readonly relativeDate?: TDate;
 }
 
 export const TimeAgo = ({
   relativeDate,
-  minInterval,
   datetime,
   live = true,
   mode = TimeAgoMode.Default,
   tooltip = true,
+  ...timeProps
 }: TimeAgoProps) => {
   const toString = useCallback(() => {
     const d = new Date(datetime);
@@ -59,8 +63,8 @@ export const TimeAgo = ({
         return 'None';
       }
     }
-    return format(d, undefined, { relativeDate, minInterval });
-  }, [datetime, minInterval, mode, relativeDate]);
+    return format(d, undefined, { relativeDate });
+  }, [datetime, mode, relativeDate]);
 
   const [time, setTime] = useState<string>(toString());
 
@@ -69,7 +73,7 @@ export const TimeAgo = ({
       const id = setInterval(() => setTime(toString()), 60000);
       return () => clearInterval(id);
     }
-  }, [datetime, relativeDate, minInterval, mode, live, toString]);
+  }, [datetime, relativeDate, mode, live, toString]);
 
   const d = new Date(datetime);
   const localeOpts: Partial<Intl.DateTimeFormatOptions> = {
@@ -80,14 +84,14 @@ export const TimeAgo = ({
   const props = {
     ...(tooltip
       ? {
-          className: 'tooltip tooltip-info tooltip-top',
+          className: `tooltip tooltip-info tooltip-top ${timeProps?.className}`,
           'data-tip': d.toLocaleString(undefined, localeOpts),
         }
       : undefined),
   };
 
   return (
-    <time {...props} dateTime={d.toISOString()}>
+    <time {...timeProps} {...props} dateTime={d.toISOString()}>
       {time}
     </time>
   );

--- a/components/react/TimeAgo.tsx
+++ b/components/react/TimeAgo.tsx
@@ -84,7 +84,7 @@ export const TimeAgo = ({
   const props = {
     ...(tooltip
       ? {
-          className: `tooltip tooltip-info tooltip-top ${timeProps?.className}`,
+          className: `tooltip tooltip-info tooltip-top ${timeProps?.className ?? ''}`,
           'data-tip': d.toLocaleString(undefined, localeOpts),
         }
       : undefined),

--- a/components/react/TimeAgo.tsx
+++ b/components/react/TimeAgo.tsx
@@ -70,7 +70,7 @@ export const TimeAgo = ({
 
   useEffect(() => {
     if (live) {
-      const id = setInterval(() => setTime(toString()), 60000);
+      const id = setInterval(() => setTime(toString()), 1000);
       return () => clearInterval(id);
     }
   }, [datetime, relativeDate, mode, live, toString]);

--- a/components/react/TimeAgo.tsx
+++ b/components/react/TimeAgo.tsx
@@ -84,7 +84,7 @@ export const TimeAgo = ({
   const props = {
     ...(tooltip
       ? {
-          className: `tooltip tooltip-top ${timeProps?.className ?? ''}`,
+          className: `tooltip tooltip-primary ${timeProps?.className ?? ''}`,
           'data-tip': d.toLocaleString(undefined, localeOpts),
         }
       : undefined),

--- a/components/react/TimeAgo.tsx
+++ b/components/react/TimeAgo.tsx
@@ -84,7 +84,7 @@ export const TimeAgo = ({
   const props = {
     ...(tooltip
       ? {
-          className: `tooltip tooltip-info tooltip-top ${timeProps?.className ?? ''}`,
+          className: `tooltip tooltip-top ${timeProps?.className ?? ''}`,
           'data-tip': d.toLocaleString(undefined, localeOpts),
         }
       : undefined),

--- a/components/react/__tests__/TimeAgo.test.tsx
+++ b/components/react/__tests__/TimeAgo.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, jest, spyOn, test } from 'bun:test';
+
+import { TimeAgo } from '@/components';
+import { formatComponent } from '@/tests';
+
+describe('TimeAgo', () => {
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test('renders correctly in the past', () => {
+    const now = new Date('2020-01-10 00:00:00 UTC');
+
+    let mockup = render(
+      <TimeAgo datetime={new Date('2020-01-09 00:00:00 UTC')} relativeDate={now} />
+    );
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('1-day');
+    expect(mockup.getByText(/1 day ago/i)).toBeInTheDocument();
+
+    mockup = render(<TimeAgo datetime={new Date('2020-01-05 00:00:00 UTC')} relativeDate={now} />);
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('5-days');
+    expect(mockup.getByText(/5 days ago/i)).toBeInTheDocument();
+
+    mockup = render(<TimeAgo datetime={new Date('2020-01-01 00:00:00 UTC')} relativeDate={now} />);
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('1-week');
+    expect(mockup.getByText(/1 week ago/i)).toBeInTheDocument();
+  });
+
+  test('renders correctly in the future', () => {
+    const now = new Date('2020-01-01 00:00:00 UTC');
+
+    let mockup = render(
+      <TimeAgo datetime={new Date('2020-01-09 00:00:00 UTC')} relativeDate={now} />
+    );
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('1-week');
+    expect(mockup.getByText(/in 1 week/i)).toBeInTheDocument();
+
+    mockup = render(<TimeAgo datetime={new Date('2020-01-05 00:00:00 UTC')} relativeDate={now} />);
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('4-days');
+    expect(mockup.getByText(/in 4 days/i)).toBeInTheDocument();
+
+    mockup = render(<TimeAgo datetime={new Date('2020-01-02 00:00:00 UTC')} relativeDate={now} />);
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('1-day');
+    expect(mockup.getByText(/in 1 day/i)).toBeInTheDocument();
+
+    mockup = render(<TimeAgo datetime={new Date('2020-01-01 00:00:00 UTC')} relativeDate={now} />);
+    expect(formatComponent(mockup.asFragment())).toMatchSnapshot('just-now');
+    expect(mockup.getByText(/just now/i)).toBeInTheDocument();
+  });
+
+  test('updates live', () => {
+    jest.setSystemTime(new Date('2020-01-09 00:00:00 UTC'));
+    const setInterval$ = spyOn(global, 'setInterval');
+
+    const comp = <TimeAgo datetime={new Date('2020-01-10 00:00:00 UTC')} />;
+    const mockup = render(comp);
+    expect(mockup.getByText(/in 1 day/i)).toBeInTheDocument();
+
+    expect(setInterval$).toHaveBeenCalledTimes(1);
+
+    jest.setSystemTime(new Date('2020-01-09 23:00:00 UTC'));
+    setInterval$.mock.calls.forEach(([callback]) => {
+      callback();
+    });
+
+    mockup.rerender(comp);
+    expect(mockup.getByText(/in 1 hour/i)).toBeInTheDocument();
+  });
+});

--- a/components/react/__tests__/__snapshots__/TimeAgo.test.tsx.snap
+++ b/components/react/__tests__/__snapshots__/TimeAgo.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TimeAgo renders correctly in the past: 1-day 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top "
+    class="tooltip tooltip-top "
     data-tip="January 9, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-09T00:00:00.000Z"
   >
@@ -15,7 +15,7 @@ exports[`TimeAgo renders correctly in the past: 1-day 1`] = `
 exports[`TimeAgo renders correctly in the past: 5-days 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top "
+    class="tooltip tooltip-top "
     data-tip="January 5, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-05T00:00:00.000Z"
   >
@@ -27,7 +27,7 @@ exports[`TimeAgo renders correctly in the past: 5-days 1`] = `
 exports[`TimeAgo renders correctly in the past: 1-week 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top "
+    class="tooltip tooltip-top "
     data-tip="January 1, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-01T00:00:00.000Z"
   >
@@ -39,7 +39,7 @@ exports[`TimeAgo renders correctly in the past: 1-week 1`] = `
 exports[`TimeAgo renders correctly in the future: 1-week 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top "
+    class="tooltip tooltip-top "
     data-tip="January 9, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-09T00:00:00.000Z"
   >
@@ -51,7 +51,7 @@ exports[`TimeAgo renders correctly in the future: 1-week 1`] = `
 exports[`TimeAgo renders correctly in the future: 4-days 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top "
+    class="tooltip tooltip-top "
     data-tip="January 5, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-05T00:00:00.000Z"
   >
@@ -63,7 +63,7 @@ exports[`TimeAgo renders correctly in the future: 4-days 1`] = `
 exports[`TimeAgo renders correctly in the future: 1-day 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top "
+    class="tooltip tooltip-top "
     data-tip="January 2, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-02T00:00:00.000Z"
   >
@@ -75,7 +75,7 @@ exports[`TimeAgo renders correctly in the future: 1-day 1`] = `
 exports[`TimeAgo renders correctly in the future: just-now 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top "
+    class="tooltip tooltip-top "
     data-tip="January 1, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-01T00:00:00.000Z"
   >

--- a/components/react/__tests__/__snapshots__/TimeAgo.test.tsx.snap
+++ b/components/react/__tests__/__snapshots__/TimeAgo.test.tsx.snap
@@ -1,0 +1,85 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimeAgo renders correctly in the past: 1-day 1`] = `
+"<DocumentFragment>
+  <time
+    class="tooltip tooltip-info tooltip-top"
+    data-tip="January 9, 2020 at 12:00:00 AM UTC"
+    datetime="2020-01-09T00:00:00.000Z"
+  >
+    1 day ago
+  </time>
+</DocumentFragment>"
+`;
+
+exports[`TimeAgo renders correctly in the past: 5-days 1`] = `
+"<DocumentFragment>
+  <time
+    class="tooltip tooltip-info tooltip-top"
+    data-tip="January 5, 2020 at 12:00:00 AM UTC"
+    datetime="2020-01-05T00:00:00.000Z"
+  >
+    5 days ago
+  </time>
+</DocumentFragment>"
+`;
+
+exports[`TimeAgo renders correctly in the past: 1-week 1`] = `
+"<DocumentFragment>
+  <time
+    class="tooltip tooltip-info tooltip-top"
+    data-tip="January 1, 2020 at 12:00:00 AM UTC"
+    datetime="2020-01-01T00:00:00.000Z"
+  >
+    1 week ago
+  </time>
+</DocumentFragment>"
+`;
+
+exports[`TimeAgo renders correctly in the future: 1-week 1`] = `
+"<DocumentFragment>
+  <time
+    class="tooltip tooltip-info tooltip-top"
+    data-tip="January 9, 2020 at 12:00:00 AM UTC"
+    datetime="2020-01-09T00:00:00.000Z"
+  >
+    in 1 week
+  </time>
+</DocumentFragment>"
+`;
+
+exports[`TimeAgo renders correctly in the future: 4-days 1`] = `
+"<DocumentFragment>
+  <time
+    class="tooltip tooltip-info tooltip-top"
+    data-tip="January 5, 2020 at 12:00:00 AM UTC"
+    datetime="2020-01-05T00:00:00.000Z"
+  >
+    in 4 days
+  </time>
+</DocumentFragment>"
+`;
+
+exports[`TimeAgo renders correctly in the future: 1-day 1`] = `
+"<DocumentFragment>
+  <time
+    class="tooltip tooltip-info tooltip-top"
+    data-tip="January 2, 2020 at 12:00:00 AM UTC"
+    datetime="2020-01-02T00:00:00.000Z"
+  >
+    in 1 day
+  </time>
+</DocumentFragment>"
+`;
+
+exports[`TimeAgo renders correctly in the future: just-now 1`] = `
+"<DocumentFragment>
+  <time
+    class="tooltip tooltip-info tooltip-top"
+    data-tip="January 1, 2020 at 12:00:00 AM UTC"
+    datetime="2020-01-01T00:00:00.000Z"
+  >
+    just now
+  </time>
+</DocumentFragment>"
+`;

--- a/components/react/__tests__/__snapshots__/TimeAgo.test.tsx.snap
+++ b/components/react/__tests__/__snapshots__/TimeAgo.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TimeAgo renders correctly in the past: 1-day 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top"
+    class="tooltip tooltip-info tooltip-top "
     data-tip="January 9, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-09T00:00:00.000Z"
   >
@@ -15,7 +15,7 @@ exports[`TimeAgo renders correctly in the past: 1-day 1`] = `
 exports[`TimeAgo renders correctly in the past: 5-days 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top"
+    class="tooltip tooltip-info tooltip-top "
     data-tip="January 5, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-05T00:00:00.000Z"
   >
@@ -27,7 +27,7 @@ exports[`TimeAgo renders correctly in the past: 5-days 1`] = `
 exports[`TimeAgo renders correctly in the past: 1-week 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top"
+    class="tooltip tooltip-info tooltip-top "
     data-tip="January 1, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-01T00:00:00.000Z"
   >
@@ -39,7 +39,7 @@ exports[`TimeAgo renders correctly in the past: 1-week 1`] = `
 exports[`TimeAgo renders correctly in the future: 1-week 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top"
+    class="tooltip tooltip-info tooltip-top "
     data-tip="January 9, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-09T00:00:00.000Z"
   >
@@ -51,7 +51,7 @@ exports[`TimeAgo renders correctly in the future: 1-week 1`] = `
 exports[`TimeAgo renders correctly in the future: 4-days 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top"
+    class="tooltip tooltip-info tooltip-top "
     data-tip="January 5, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-05T00:00:00.000Z"
   >
@@ -63,7 +63,7 @@ exports[`TimeAgo renders correctly in the future: 4-days 1`] = `
 exports[`TimeAgo renders correctly in the future: 1-day 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top"
+    class="tooltip tooltip-info tooltip-top "
     data-tip="January 2, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-02T00:00:00.000Z"
   >
@@ -75,7 +75,7 @@ exports[`TimeAgo renders correctly in the future: 1-day 1`] = `
 exports[`TimeAgo renders correctly in the future: just-now 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-info tooltip-top"
+    class="tooltip tooltip-info tooltip-top "
     data-tip="January 1, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-01T00:00:00.000Z"
   >

--- a/components/react/__tests__/__snapshots__/TimeAgo.test.tsx.snap
+++ b/components/react/__tests__/__snapshots__/TimeAgo.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TimeAgo renders correctly in the past: 1-day 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-top "
+    class="tooltip tooltip-primary "
     data-tip="January 9, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-09T00:00:00.000Z"
   >
@@ -15,7 +15,7 @@ exports[`TimeAgo renders correctly in the past: 1-day 1`] = `
 exports[`TimeAgo renders correctly in the past: 5-days 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-top "
+    class="tooltip tooltip-primary "
     data-tip="January 5, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-05T00:00:00.000Z"
   >
@@ -27,7 +27,7 @@ exports[`TimeAgo renders correctly in the past: 5-days 1`] = `
 exports[`TimeAgo renders correctly in the past: 1-week 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-top "
+    class="tooltip tooltip-primary "
     data-tip="January 1, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-01T00:00:00.000Z"
   >
@@ -39,7 +39,7 @@ exports[`TimeAgo renders correctly in the past: 1-week 1`] = `
 exports[`TimeAgo renders correctly in the future: 1-week 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-top "
+    class="tooltip tooltip-primary "
     data-tip="January 9, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-09T00:00:00.000Z"
   >
@@ -51,7 +51,7 @@ exports[`TimeAgo renders correctly in the future: 1-week 1`] = `
 exports[`TimeAgo renders correctly in the future: 4-days 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-top "
+    class="tooltip tooltip-primary "
     data-tip="January 5, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-05T00:00:00.000Z"
   >
@@ -63,7 +63,7 @@ exports[`TimeAgo renders correctly in the future: 4-days 1`] = `
 exports[`TimeAgo renders correctly in the future: 1-day 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-top "
+    class="tooltip tooltip-primary "
     data-tip="January 2, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-02T00:00:00.000Z"
   >
@@ -75,7 +75,7 @@ exports[`TimeAgo renders correctly in the future: 1-day 1`] = `
 exports[`TimeAgo renders correctly in the future: just-now 1`] = `
 "<DocumentFragment>
   <time
-    class="tooltip tooltip-top "
+    class="tooltip tooltip-primary "
     data-tip="January 1, 2020 at 12:00:00 AM UTC"
     datetime="2020-01-01T00:00:00.000Z"
   >

--- a/components/react/index.ts
+++ b/components/react/index.ts
@@ -8,3 +8,4 @@ export * from './ModalDialog';
 export * from './TokenBalance';
 export * from './Pagination';
 export * from './SearchFilter';
+export * from './TimeAgo';

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "tailwind-scrollbar-hide": "2.0.0",
     "tailwindcss": "4.0.17",
     "three": "0.174.0",
-    "timeago.js": "^4.0.2",
+    "timeago.js": "4.0.2",
     "yup": "1.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "tailwind-scrollbar-hide": "2.0.0",
     "tailwindcss": "4.0.17",
     "three": "0.174.0",
+    "timeago.js": "^4.0.2",
     "yup": "1.6.1"
   },
   "devDependencies": {

--- a/tests/data.ts
+++ b/tests/data.ts
@@ -252,7 +252,7 @@ export const mockTransactions: TxMessage[] = [
     fee: { amount: [{ amount: '1', denom: 'denom1' }], gas: '1' },
     memo: 'memo1',
     height: 1,
-    timestamp: 'timestamp1',
+    timestamp: '1900-01-01',
     error: '',
     proposal_ids: ['proposal1'],
   },


### PR DESCRIPTION
Also move other "time ago" labels to new component, and fix some rendering and overflow issues with the tooltip.

Now history box looks like this:

<img width="1258" alt="CleanShot 2025-03-28 at 10 23 07@2x" src="https://github.com/user-attachments/assets/c287a64e-4d86-437d-b19d-9700b726cd9f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a relative time display across transaction histories and proposals, providing users with a friendlier view of past and upcoming dates.

- **Refactor**
  - Streamlined the layout to better highlight time information by replacing older date formatting methods with an enhanced, live-updating time component.

- **Chores**
  - Added a new dependency for improved, dynamic time display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->