### PR TITLE
fix: show fees on the social tx signing modal

### DIFF
--- a/components/react/__snapshots__/authSignerModal.test.tsx.snap
+++ b/components/react/__snapshots__/authSignerModal.test.tsx.snap
@@ -1,6 +1,50 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PromptSignModalInner should render 1`] = `
+exports[`PromptSignModalInner should render with standard fee data 1`] = `
+"<DocumentFragment>
+  <div
+    class="_14der0i88"
+    data-interchain-ui-provider="true"
+    data-is-controlled="false"
+    style="visibility: visible;"
+  />
+</DocumentFragment>"
+`;
+
+exports[`PromptSignModalInner should render with multiple fee currencies 1`] = `
+"<DocumentFragment>
+  <div
+    class="_14der0i88"
+    data-interchain-ui-provider="true"
+    data-is-controlled="false"
+    style="visibility: visible;"
+  />
+</DocumentFragment>"
+`;
+
+exports[`PromptSignModalInner should render with gas-only fee (no amount) 1`] = `
+"<DocumentFragment>
+  <div
+    class="_14der0i88"
+    data-interchain-ui-provider="true"
+    data-is-controlled="false"
+    style="visibility: visible;"
+  />
+</DocumentFragment>"
+`;
+
+exports[`PromptSignModalInner should render with SignDoc fee data 1`] = `
+"<DocumentFragment>
+  <div
+    class="_14der0i88"
+    data-interchain-ui-provider="true"
+    data-is-controlled="false"
+    style="visibility: visible;"
+  />
+</DocumentFragment>"
+`;
+
+exports[`PromptSignModalInner should render with fallback when no fee data 1`] = `
 "<DocumentFragment>
   <div
     class="_14der0i88"

--- a/components/react/__tests__/__snapshots__/ModalDialog.test.tsx.snap
+++ b/components/react/__tests__/__snapshots__/ModalDialog.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ModalDialog renders correctly: portal 1`] = `
   class="modal modal-open fixed flex p-0 m-0 top-0 left-0 undefined"
   data-headlessui-state="open"
   data-open=""
-  id="headlessui-dialog-«r1v»"
+  id="headlessui-dialog-«r3m»"
   role="dialog"
   style="background-color: transparent; align-items: center; justify-content: center; height: 100vh; width: 100vw;"
   tabindex="-1"
@@ -22,7 +22,7 @@ exports[`ModalDialog renders correctly: portal 1`] = `
     class="undefined modal-box mx-auto rounded-[24px] bg-[#F4F4FF] dark:bg-[#1D192D] shadow-lg relative"
     data-headlessui-state="open"
     data-open=""
-    id="headlessui-dialog-panel-«r26»"
+    id="headlessui-dialog-panel-«r3t»"
   >
     bound HTMLFormElement {
       "0": <button

--- a/components/react/authSignerModal.test.tsx
+++ b/components/react/authSignerModal.test.tsx
@@ -1,3 +1,4 @@
+import { SignData } from '@cosmos-kit/web3auth';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import React from 'react';
@@ -5,6 +6,71 @@ import React from 'react';
 import { LedgerSignModalInner, PromptSignModalInner } from '@/components';
 import { clearAllMocks, formatComponent, mockRouter } from '@/tests';
 import { renderWithChainProvider } from '@/tests/render';
+
+// Mock SignData for testing fee extraction
+const mockSignDataWithStdFee: SignData = {
+  type: 'amino',
+  value: {
+    fee: {
+      amount: [{ denom: 'umfx', amount: '123000' }],
+      gas: '200000',
+    },
+    msgs: [],
+    memo: '',
+    chain_id: 'manifest-1',
+    account_number: '0',
+    sequence: '0',
+  },
+};
+
+const mockSignDataWithMultipleFees: SignData = {
+  type: 'amino',
+  value: {
+    fee: {
+      amount: [
+        { denom: 'umfx', amount: '123000' },
+        { denom: 'uatom', amount: '456000' },
+      ],
+      gas: '300000',
+    },
+    msgs: [],
+    memo: '',
+    chain_id: 'manifest-1',
+    account_number: '0',
+    sequence: '0',
+  },
+};
+
+const mockSignDataWithNoFeeAmount: SignData = {
+  type: 'amino',
+  value: {
+    fee: {
+      amount: [],
+      gas: '150000',
+    },
+    msgs: [],
+    memo: '',
+    chain_id: 'manifest-1',
+    account_number: '0',
+    sequence: '0',
+  },
+};
+
+const mockSignDataWithSignDoc: SignData = {
+  type: 'direct',
+  value: {
+    bodyBytes: new Uint8Array(),
+    authInfoBytes: new Uint8Array([
+      10, 83, 10, 81, 10, 40, 47, 99, 111, 115, 109, 111, 115, 46, 99, 114, 121, 112, 116, 111, 46,
+      115, 101, 99, 112, 50, 53, 54, 107, 49, 46, 80, 117, 98, 75, 101, 121, 18, 37, 10, 33, 3, 182,
+      111, 159, 126, 218, 135, 87, 104, 213, 191, 156, 207, 126, 164, 78, 123, 29, 91, 122, 90, 39,
+      172, 178, 239, 230, 244, 188, 26, 206, 47, 69, 134, 18, 4, 8, 127, 24, 1, 18, 19, 10, 13, 10,
+      4, 117, 109, 102, 120, 18, 5, 49, 50, 51, 52, 53, 16, 128, 150, 12,
+    ]),
+    accountNumber: BigInt(0),
+    chainId: 'manifest-1',
+  },
+};
 
 describe('PromptSignModalInner', () => {
   beforeEach(() => {
@@ -16,15 +82,73 @@ describe('PromptSignModalInner', () => {
     clearAllMocks();
   });
 
-  test('should render', () => {
+  test('should render with standard fee data', () => {
+    const wrapper = renderWithChainProvider(
+      <PromptSignModalInner visible={true} onClose={() => {}} data={mockSignDataWithStdFee} />
+    );
+    expect(screen.getByText('Approve')).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeVisible();
+    expect(screen.getByText('Fee:')).toBeInTheDocument();
+    expect(screen.getByText('0.123 MFX')).toBeInTheDocument();
+    expect(formatComponent(wrapper.asFragment())).toMatchSnapshot();
+  });
+
+  test('should render with multiple fee currencies', () => {
+    const wrapper = renderWithChainProvider(
+      <PromptSignModalInner visible={true} onClose={() => {}} data={mockSignDataWithMultipleFees} />
+    );
+    expect(screen.getByText('Fee:')).toBeInTheDocument();
+    expect(screen.getByText('0.123 MFX, 0.456 ATOM')).toBeInTheDocument();
+    expect(formatComponent(wrapper.asFragment())).toMatchSnapshot();
+  });
+
+  test('should render with gas-only fee (no amount)', () => {
+    const wrapper = renderWithChainProvider(
+      <PromptSignModalInner visible={true} onClose={() => {}} data={mockSignDataWithNoFeeAmount} />
+    );
+    expect(screen.getByText('Fee:')).toBeInTheDocument();
+    expect(screen.getByText('Gas: 150000')).toBeInTheDocument();
+    expect(formatComponent(wrapper.asFragment())).toMatchSnapshot();
+  });
+
+  test('should render with SignDoc fee data', () => {
+    const wrapper = renderWithChainProvider(
+      <PromptSignModalInner visible={true} onClose={() => {}} data={mockSignDataWithSignDoc} />
+    );
+    expect(screen.getByText('Fee:')).toBeInTheDocument();
+    // This should extract fee from authInfoBytes
+    expect(formatComponent(wrapper.asFragment())).toMatchSnapshot();
+  });
+
+  test('should render with fallback when no fee data', () => {
     const wrapper = renderWithChainProvider(
       <PromptSignModalInner visible={true} onClose={() => {}} />
     );
     expect(screen.getByText('Approve')).toBeInTheDocument();
     const dialog = screen.getByRole('dialog');
     expect(dialog).toBeVisible();
-
+    expect(screen.getByText('Fee:')).toBeInTheDocument();
+    expect(screen.getByText('Gas: 0')).toBeInTheDocument();
     expect(formatComponent(wrapper.asFragment())).toMatchSnapshot();
+  });
+
+  test('should display fee label and value on separate lines', () => {
+    const wrapper = renderWithChainProvider(
+      <PromptSignModalInner visible={true} onClose={() => {}} data={mockSignDataWithStdFee} />
+    );
+
+    // Check that fee label and value are in separate spans
+    const feeLabel = screen.getByText('Fee:');
+    const feeValue = screen.getByText('0.123 MFX');
+
+    expect(feeLabel).toBeInTheDocument();
+    expect(feeValue).toBeInTheDocument();
+
+    // Check the layout structure
+    const feeContainer = feeLabel.closest('.flex.flex-col');
+    expect(feeContainer).toBeInTheDocument();
+    expect(feeContainer).toHaveClass('items-start', 'justify-start');
   });
 
   test('should not be visible initially when visible prop is false', () => {

--- a/components/react/authSignerModal.tsx
+++ b/components/react/authSignerModal.tsx
@@ -3,6 +3,7 @@ import { useChain, useWallet } from '@cosmos-kit/react';
 import { SignData } from '@cosmos-kit/web3auth';
 import { Dialog } from '@headlessui/react';
 import { MsgSend } from '@liftedinit/manifestjs/dist/codegen/cosmos/bank/v1beta1/tx';
+import { Coin } from '@liftedinit/manifestjs/dist/codegen/cosmos/base/v1beta1/coin';
 import {
   MsgCreateGroupWithPolicy,
   MsgSubmitProposal,
@@ -221,6 +222,14 @@ const DisplayDataToSign = ({
   // Helper function to extract fee information from SignData
   const extractFeeInfo = (signData: SignData) => {
     try {
+      // Handle case where signData or signData.value is undefined
+      if (!signData || !signData.value || typeof signData.value !== 'object') {
+        return {
+          amount: [],
+          gas: '0',
+        };
+      }
+
       if ('fee' in signData.value) {
         // StdSignDoc case - fee is directly available
         const stdFee = signData.value.fee;
@@ -256,7 +265,7 @@ const DisplayDataToSign = ({
     }
 
     const feeAmounts = amount
-      .map((coin: any) => {
+      .map((coin: Coin) => {
         // Convert from utoken to token (assuming 6 decimal places for most tokens)
         const amountNum = parseInt(coin.amount || '0');
         const denom = coin.denom || '';


### PR DESCRIPTION
#445


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a visible "Fee:" summary block to the transaction signing modal, displaying formatted fee and gas information alongside existing transaction details.
- **Tests**
  - Expanded test coverage to verify accurate display of transaction fees in various scenarios within the signing modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->