### PR TITLE
fix: transaction issue from social wallets

### DIFF
--- a/components/react/__tests__/__snapshots__/ModalDialog.test.tsx.snap
+++ b/components/react/__tests__/__snapshots__/ModalDialog.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ModalDialog renders correctly: portal 1`] = `
   class="modal modal-open fixed flex p-0 m-0 top-0 left-0 undefined"
   data-headlessui-state="open"
   data-open=""
-  id="headlessui-dialog-«r3m»"
+  id="headlessui-dialog-«normalized»"
   role="dialog"
   style="background-color: transparent; align-items: center; justify-content: center; height: 100vh; width: 100vw;"
   tabindex="-1"
@@ -22,7 +22,7 @@ exports[`ModalDialog renders correctly: portal 1`] = `
     class="undefined modal-box mx-auto rounded-[24px] bg-[#F4F4FF] dark:bg-[#1D192D] shadow-lg relative"
     data-headlessui-state="open"
     data-open=""
-    id="headlessui-dialog-panel-«r3t»"
+    id="headlessui-dialog-panel-«normalized»"
   >
     bound HTMLFormElement {
       "0": <button

--- a/components/react/__tests__/modal.test.tsx
+++ b/components/react/__tests__/modal.test.tsx
@@ -192,7 +192,7 @@ describe('TailwindModal', () => {
   });
 
   describe('isWalletConnectionError function', () => {
-    test('should identify wallet connection errors correctly', () => {
+    test('should have TailwindModal component defined', () => {
       // Import the modal and test that the component is properly defined
       expect(TailwindModal).toBeDefined();
     });
@@ -430,29 +430,6 @@ describe('TailwindModal', () => {
 
       // Should show NotExist view
       expect(screen.getByTestId('not-exist')).toBeInTheDocument();
-    });
-  });
-
-  describe('QR Code State Management', () => {
-    test('should disconnect QR wallet when modal closes', () => {
-      const connectingWallet = {
-        ...mockWallet,
-        walletStatus: WalletStatus.Connecting,
-        disconnect: jest.fn(),
-      };
-
-      const { rerender } = render(
-        <TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={mockWalletRepo} />
-      );
-
-      // Simulate QR wallet being set
-      fireEvent.click(screen.getByText('Keplr'));
-
-      // Close modal
-      rerender(<TailwindModal isOpen={false} setOpen={mockSetOpen} walletRepo={mockWalletRepo} />);
-
-      // Should clean up QR wallet
-      expect(screen.queryByTestId('qr-code')).not.toBeInTheDocument();
     });
   });
 });

--- a/components/react/__tests__/modal.test.tsx
+++ b/components/react/__tests__/modal.test.tsx
@@ -1,0 +1,458 @@
+import { State } from '@cosmos-kit/core';
+import { Web3AuthClient } from '@cosmos-kit/web3auth';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, jest, mock, spyOn, test } from 'bun:test';
+import type { ChainWalletBase } from 'cosmos-kit';
+import { WalletStatus } from 'cosmos-kit';
+import React from 'react';
+
+import { TailwindModal } from '@/components/react/modal';
+import { clearAllMocks, mockModule, mockRouter } from '@/tests';
+import { renderWithChainProvider } from '@/tests/render';
+
+describe('TailwindModal', () => {
+  let mockWalletRepo: any;
+  let mockWallet: ChainWalletBase;
+  let mockSetOpen: jest.Mock;
+  let useDeviceDetectMock: any;
+  let useClientResetMock: any;
+  let originalWindow: any;
+
+  beforeEach(() => {
+    // Mock router and window object
+    mockRouter();
+
+    // Store original window if it exists
+    originalWindow = (global as any).window;
+
+    // Mock window object with all necessary properties for HeadlessUI and other tests
+    (global as any).window = {
+      ...originalWindow,
+      keplr: undefined,
+      open: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      localStorage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+        clear: jest.fn(),
+      },
+      matchMedia: jest.fn(() => ({
+        matches: false,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+      navigator: {
+        platform: 'MacIntel',
+        userAgent: 'test',
+        maxTouchPoints: 0,
+      },
+      document: {
+        body: {
+          style: {},
+        },
+      },
+    };
+
+    // Mock console.error to prevent test noise
+    spyOn(console, 'error').mockImplementation(() => {});
+
+    mockSetOpen = jest.fn();
+
+    mockWallet = {
+      walletInfo: {
+        name: 'keplr-extension',
+        prettyName: 'Keplr',
+        mode: 'extension',
+        logo: 'logo.png',
+      },
+      walletStatus: WalletStatus.Disconnected,
+      walletName: 'keplr-extension',
+      message: '',
+      username: undefined,
+      address: undefined,
+      isWalletNotExist: false,
+      disconnect: jest.fn(),
+      setMessage: jest.fn(),
+      client: {
+        setActions: jest.fn(),
+      },
+      downloadInfo: {
+        link: 'https://chrome.google.com/webstore/detail/keplr/dmkamcknogkgcdfhhbddcghachkejeap',
+      },
+    } as any;
+
+    mockWalletRepo = {
+      current: mockWallet,
+      wallets: [mockWallet],
+      getWallet: jest.fn(() => mockWallet),
+      connect: jest.fn(() => Promise.resolve()),
+    };
+
+    // Mock hooks using mockModule
+    useDeviceDetectMock = mockModule('@/hooks', () => ({
+      useDeviceDetect: jest.fn(() => ({ isMobile: false })),
+    }));
+
+    useClientResetMock = mockModule('@/hooks/useClientReset', () => ({
+      useClientReset: jest.fn(() => ({ forceCompleteReset: jest.fn() })),
+    }));
+
+    // Mock the modal views
+    mockModule('@/components/react/views', () => ({
+      WalletList: ({ onWalletClicked, onClose }: any) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'wallet-list' },
+          React.createElement(
+            'button',
+            { onClick: () => onWalletClicked('keplr-extension') },
+            'Keplr'
+          ),
+          React.createElement(
+            'button',
+            { onClick: () => onWalletClicked('cosmos-extension-metamask') },
+            'Metamask'
+          ),
+          React.createElement('button', { onClick: () => onWalletClicked('Email') }, 'Email'),
+          React.createElement('button', { onClick: () => onWalletClicked('SMS') }, 'SMS'),
+          React.createElement('button', { onClick: onClose }, 'Close')
+        ),
+      Connected: ({ onClose, disconnect }: any) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'connected' },
+          React.createElement('button', { onClick: disconnect }, 'Disconnect'),
+          React.createElement('button', { onClick: onClose }, 'Close')
+        ),
+      Connecting: ({ onClose }: any) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'connecting' },
+          React.createElement('button', { onClick: onClose }, 'Close')
+        ),
+      Error: ({ onClose, onReconnect }: any) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'error' },
+          React.createElement('button', { onClick: onReconnect }, 'Reconnect'),
+          React.createElement('button', { onClick: onClose }, 'Close')
+        ),
+      NotExist: ({ onClose, onInstall }: any) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'not-exist' },
+          React.createElement('button', { onClick: onInstall }, 'Install'),
+          React.createElement('button', { onClick: onClose }, 'Close')
+        ),
+      QRCodeView: ({ onClose, onReturn }: any) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'qr-code' },
+          React.createElement('button', { onClick: onReturn }, 'Back'),
+          React.createElement('button', { onClick: onClose }, 'Close')
+        ),
+      EmailInput: ({ onClose, onReturn, onSubmit }: any) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'email-input' },
+          React.createElement(
+            'button',
+            { onClick: () => onSubmit('test@example.com') },
+            'Submit Email'
+          ),
+          React.createElement('button', { onClick: onReturn }, 'Back'),
+          React.createElement('button', { onClick: onClose }, 'Close')
+        ),
+      SMSInput: ({ onClose, onReturn, onSubmit }: any) =>
+        React.createElement(
+          'div',
+          { 'data-testid': 'sms-input' },
+          React.createElement('button', { onClick: () => onSubmit('+1234567890') }, 'Submit SMS'),
+          React.createElement('button', { onClick: onReturn }, 'Back'),
+          React.createElement('button', { onClick: onClose }, 'Close')
+        ),
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearAllMocks();
+    mock.restore();
+    jest.clearAllMocks();
+
+    // Restore original window
+    if (originalWindow) {
+      (global as any).window = originalWindow;
+    }
+  });
+
+  describe('isWalletConnectionError function', () => {
+    test('should identify wallet connection errors correctly', () => {
+      // Import the modal and test that the component is properly defined
+      expect(TailwindModal).toBeDefined();
+    });
+  });
+
+  describe('Modal State Management', () => {
+    test('should disconnect QR wallet when modal closes', () => {
+      const connectingWallet = {
+        ...mockWallet,
+        walletStatus: WalletStatus.Connecting,
+        disconnect: jest.fn(),
+      };
+
+      const { rerender } = render(
+        <TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={mockWalletRepo} />
+      );
+
+      // Simulate QR wallet being set
+      fireEvent.click(screen.getByText('Keplr'));
+
+      // Close modal
+      rerender(<TailwindModal isOpen={false} setOpen={mockSetOpen} walletRepo={mockWalletRepo} />);
+
+      // Should clean up QR wallet
+      expect(screen.queryByTestId('qr-code')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Wallet Status Changes', () => {
+    test('should handle different wallet statuses when modal opens', () => {
+      const connectedWallet = {
+        ...mockWallet,
+        walletStatus: WalletStatus.Connected,
+      };
+
+      const connectedWalletRepo = {
+        ...mockWalletRepo,
+        current: connectedWallet,
+      };
+
+      render(
+        <TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={connectedWalletRepo} />
+      );
+
+      expect(screen.getByTestId('connected')).toBeInTheDocument();
+    });
+
+    test('should handle error wallet status', () => {
+      const errorWallet = {
+        ...mockWallet,
+        walletStatus: WalletStatus.Error,
+      };
+
+      const errorWalletRepo = {
+        ...mockWalletRepo,
+        current: errorWallet,
+      };
+
+      render(<TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={errorWalletRepo} />);
+
+      expect(screen.getByTestId('error')).toBeInTheDocument();
+    });
+
+    test('should handle rejected wallet status', () => {
+      const rejectedWallet = {
+        ...mockWallet,
+        walletStatus: WalletStatus.Rejected,
+      };
+
+      const rejectedWalletRepo = {
+        ...mockWalletRepo,
+        current: rejectedWallet,
+      };
+
+      render(<TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={rejectedWalletRepo} />);
+
+      expect(screen.getByTestId('error')).toBeInTheDocument();
+    });
+
+    test('should handle not exist wallet status', () => {
+      const notExistWallet = {
+        ...mockWallet,
+        walletStatus: WalletStatus.NotExist,
+      };
+
+      const notExistWalletRepo = {
+        ...mockWalletRepo,
+        current: notExistWallet,
+      };
+
+      render(<TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={notExistWalletRepo} />);
+
+      expect(screen.getByTestId('not-exist')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('should handle missing wallet from getWallet', async () => {
+      const emptyWalletRepo = {
+        ...mockWalletRepo,
+        getWallet: jest.fn(() => undefined),
+      };
+
+      render(<TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={emptyWalletRepo} />);
+
+      fireEvent.click(screen.getByText('Keplr'));
+
+      // Should not crash and wallet should remain disconnected
+      expect(emptyWalletRepo.getWallet).toHaveBeenCalledWith('keplr-extension');
+    });
+
+    test('should handle forceCompleteReset on connected wallet disconnect', async () => {
+      const mockForceCompleteReset = jest.fn();
+      useClientResetMock.mocks.useClientReset.mockReturnValue({
+        forceCompleteReset: mockForceCompleteReset,
+      });
+
+      const connectedWallet = {
+        ...mockWallet,
+        walletStatus: WalletStatus.Connected,
+        disconnect: jest.fn(),
+      };
+
+      const connectedWalletRepo = {
+        ...mockWalletRepo,
+        current: connectedWallet,
+      };
+
+      render(
+        <TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={connectedWalletRepo} />
+      );
+
+      expect(screen.getByTestId('connected')).toBeInTheDocument();
+
+      // Click disconnect button
+      fireEvent.click(screen.getByText('Disconnect'));
+
+      expect(connectedWallet.disconnect).toHaveBeenCalled();
+      expect(mockForceCompleteReset).toHaveBeenCalled();
+    });
+
+    test('should handle successful SMS wallet connection', async () => {
+      const mockClient = {
+        setLoginHint: jest.fn(),
+      };
+
+      const smsWallet = {
+        ...mockWallet,
+        walletInfo: { ...mockWallet.walletInfo, prettyName: 'SMS', name: 'sms' },
+        client: mockClient,
+      };
+
+      // Make mockClient an instance of Web3AuthClient for instanceof check
+      Object.setPrototypeOf(mockClient, Web3AuthClient.prototype);
+
+      const smsWalletRepo = {
+        ...mockWalletRepo,
+        current: smsWallet,
+        wallets: [smsWallet],
+        getWallet: jest.fn(() => smsWallet),
+        connect: jest.fn(() => Promise.resolve()),
+      };
+
+      render(<TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={smsWalletRepo} />);
+
+      fireEvent.click(screen.getByText('SMS'));
+      expect(screen.getByTestId('sms-input')).toBeInTheDocument();
+
+      // Test SMS submission
+      fireEvent.click(screen.getByText('Submit SMS'));
+
+      expect(mockClient.setLoginHint).toHaveBeenCalledWith('+1234567890');
+      expect(smsWalletRepo.connect).toHaveBeenCalledWith('sms');
+    });
+
+    test('should handle Keplr extension not available', () => {
+      // Mock window.keplr as undefined
+      (global as any).window.keplr = undefined;
+
+      const keplrWallet = {
+        ...mockWallet,
+        walletInfo: { ...mockWallet.walletInfo, name: 'keplr-extension' },
+      };
+
+      const keplrWalletRepo = {
+        ...mockWalletRepo,
+        getWallet: jest.fn(() => keplrWallet),
+      };
+
+      render(<TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={keplrWalletRepo} />);
+
+      fireEvent.click(screen.getByText('Keplr'));
+
+      // Should show NotExist view for missing Keplr extension
+      expect(screen.getByTestId('not-exist')).toBeInTheDocument();
+    });
+
+    test('should handle connecting wallet status with wallet-connect mode', () => {
+      // Mock as desktop device
+      useDeviceDetectMock.mocks.useDeviceDetect.mockReturnValue({ isMobile: false });
+
+      const connectingWalletConnectWallet = {
+        ...mockWallet,
+        walletStatus: WalletStatus.Connecting,
+        walletInfo: { ...mockWallet.walletInfo, mode: 'wallet-connect' },
+      };
+
+      const connectingWalletRepo = {
+        ...mockWalletRepo,
+        current: connectingWalletConnectWallet,
+      };
+
+      render(
+        <TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={connectingWalletRepo} />
+      );
+
+      // Should show QR code view for connecting wallet-connect wallet on desktop
+      expect(screen.getByTestId('qr-code')).toBeInTheDocument();
+    });
+
+    test('should handle wallet with isWalletNotExist flag', () => {
+      const notExistWallet = {
+        ...mockWallet,
+        isWalletNotExist: true,
+      };
+
+      const notExistWalletRepo = {
+        ...mockWalletRepo,
+        getWallet: jest.fn(() => notExistWallet),
+      };
+
+      render(<TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={notExistWalletRepo} />);
+
+      fireEvent.click(screen.getByText('Keplr'));
+
+      // Should show NotExist view
+      expect(screen.getByTestId('not-exist')).toBeInTheDocument();
+    });
+  });
+
+  describe('QR Code State Management', () => {
+    test('should disconnect QR wallet when modal closes', () => {
+      const connectingWallet = {
+        ...mockWallet,
+        walletStatus: WalletStatus.Connecting,
+        disconnect: jest.fn(),
+      };
+
+      const { rerender } = render(
+        <TailwindModal isOpen={true} setOpen={mockSetOpen} walletRepo={mockWalletRepo} />
+      );
+
+      // Simulate QR wallet being set
+      fireEvent.click(screen.getByText('Keplr'));
+
+      // Close modal
+      rerender(<TailwindModal isOpen={false} setOpen={mockSetOpen} walletRepo={mockWalletRepo} />);
+
+      // Should clean up QR wallet
+      expect(screen.queryByTestId('qr-code')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/contexts/__tests__/web3AuthContext.test.tsx
+++ b/contexts/__tests__/web3AuthContext.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, jest, test } from 'bun:test';
 import React from 'react';
 
@@ -121,55 +121,52 @@ describe('Web3AuthContext', () => {
     }
   });
 
-  test('isSigning state management works correctly', () => {
+  test('isSigning state management works correctly', async () => {
     let setSigningFunction: ((isSigning: boolean) => void) | undefined;
-    let isSigningValue: boolean | undefined;
 
-    const TestComponent = () => {
+    const TestComponentWithState = () => {
       const context = React.useContext(Web3AuthContext);
       setSigningFunction = context.setIsSigning;
-      isSigningValue = context.isSigning;
       return (
         <div>
           <span data-testid="signing-state">{context.isSigning.toString()}</span>
+          <button
+            data-testid="toggle-signing"
+            onClick={() => context.setIsSigning(!context.isSigning)}
+          >
+            Toggle
+          </button>
         </div>
       );
     };
 
-    const { getByTestId, rerender } = render(
+    const { getByTestId } = render(
       <Web3AuthProvider>
-        <TestComponent />
+        <TestComponentWithState />
       </Web3AuthProvider>
     );
 
     // Initial state should be false
     expect(getByTestId('signing-state').textContent).toBe('false');
 
-    // Set signing to true
+    // Test state changes by triggering the function
     if (setSigningFunction) {
       setSigningFunction(true);
-      rerender(
-        <Web3AuthProvider>
-          <TestComponent />
-        </Web3AuthProvider>
-      );
-      expect(getByTestId('signing-state').textContent).toBe('true');
+      await waitFor(() => {
+        expect(getByTestId('signing-state').textContent).toBe('true');
+      });
 
-      // Set signing back to false
       setSigningFunction(false);
-      rerender(
-        <Web3AuthProvider>
-          <TestComponent />
-        </Web3AuthProvider>
-      );
-      expect(getByTestId('signing-state').textContent).toBe('false');
+      await waitFor(() => {
+        expect(getByTestId('signing-state').textContent).toBe('false');
+      });
     }
   });
 
-  test('promptId state management works correctly', () => {
+  test('promptId state management works correctly', async () => {
     let setPromptIdFunction: ((promptId: string | undefined) => void) | undefined;
 
-    const TestComponent = () => {
+    const TestComponentWithState = () => {
       const context = React.useContext(Web3AuthContext);
       setPromptIdFunction = context.setPromptId;
       return (
@@ -179,33 +176,27 @@ describe('Web3AuthContext', () => {
       );
     };
 
-    const { getByTestId, rerender } = render(
+    const { getByTestId } = render(
       <Web3AuthProvider>
-        <TestComponent />
+        <TestComponentWithState />
       </Web3AuthProvider>
     );
 
     // Initial state should be undefined
     expect(getByTestId('prompt-id').textContent).toBe('undefined');
 
-    // Set prompt ID
+    // Test state changes by triggering the function
     if (setPromptIdFunction) {
       setPromptIdFunction('test-prompt');
-      rerender(
-        <Web3AuthProvider>
-          <TestComponent />
-        </Web3AuthProvider>
-      );
-      expect(getByTestId('prompt-id').textContent).toBe('test-prompt');
+      await waitFor(() => {
+        expect(getByTestId('prompt-id').textContent).toBe('test-prompt');
+      });
 
       // Clear prompt ID
       setPromptIdFunction(undefined);
-      rerender(
-        <Web3AuthProvider>
-          <TestComponent />
-        </Web3AuthProvider>
-      );
-      expect(getByTestId('prompt-id').textContent).toBe('undefined');
+      await waitFor(() => {
+        expect(getByTestId('prompt-id').textContent).toBe('undefined');
+      });
     }
   });
 });

--- a/contexts/__tests__/web3AuthContext.test.tsx
+++ b/contexts/__tests__/web3AuthContext.test.tsx
@@ -1,0 +1,211 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, jest, test } from 'bun:test';
+import React from 'react';
+
+import { clearAllMocks, mockModule } from '@/tests';
+
+import { Web3AuthContext, Web3AuthProvider } from '../web3AuthContext';
+
+describe('Web3AuthContext', () => {
+  beforeEach(() => {
+    // Mock the required modules
+    mockModule('@cosmos-kit/web3auth', () => ({
+      makeWeb3AuthWallets: jest.fn().mockReturnValue([]),
+      Web3AuthWallet: class MockWeb3AuthWallet {
+        walletStatus = 'Disconnected';
+        walletInfo = { name: 'test-wallet' };
+        client = {
+          setLoginHint: jest.fn(),
+        };
+        async disconnect() {
+          return Promise.resolve();
+        }
+      },
+      Web3AuthClient: class MockWeb3AuthClient {
+        setLoginHint = jest.fn();
+      },
+    }));
+
+    mockModule('@web3auth/auth', () => ({
+      WEB3AUTH_NETWORK_TYPE: {
+        TESTNET: 'testnet',
+        MAINNET: 'mainnet',
+      },
+    }));
+
+    mockModule('cosmos-kit', () => ({
+      wallets: {
+        for: jest.fn().mockReturnValue([]),
+      },
+    }));
+
+    mockModule('@cosmos-kit/cosmos-extension-metamask', () => ({
+      wallets: [],
+    }));
+
+    // Mock environment config
+    mockModule('@/config/env', () => ({
+      default: {
+        web3AuthNetwork: 'testnet',
+        web3AuthClientId: 'test-client-id',
+      },
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test('provides resetWeb3AuthClients function', () => {
+    const TestComponent = () => {
+      const context = React.useContext(Web3AuthContext);
+      return <div data-testid="reset-type">{typeof context.resetWeb3AuthClients}</div>;
+    };
+
+    const { getByTestId } = render(
+      <Web3AuthProvider>
+        <TestComponent />
+      </Web3AuthProvider>
+    );
+    expect(getByTestId('reset-type').textContent).toBe('function');
+  });
+
+  test('context provides all required values', () => {
+    const TestComponent = () => {
+      const context = React.useContext(Web3AuthContext);
+      return (
+        <div>
+          <span data-testid="is-signing">{context.isSigning.toString()}</span>
+          <span data-testid="set-signing">{typeof context.setIsSigning}</span>
+          <span data-testid="set-prompt">{typeof context.setPromptId}</span>
+          <span data-testid="reset-clients">{typeof context.resetWeb3AuthClients}</span>
+          <span data-testid="wallets-length">{context.wallets.length}</span>
+        </div>
+      );
+    };
+
+    const { getByTestId } = render(
+      <Web3AuthProvider>
+        <TestComponent />
+      </Web3AuthProvider>
+    );
+
+    expect(getByTestId('is-signing').textContent).toBe('false');
+    expect(getByTestId('set-signing').textContent).toBe('function');
+    expect(getByTestId('set-prompt').textContent).toBe('function');
+    expect(getByTestId('reset-clients').textContent).toBe('function');
+    expect(parseInt(getByTestId('wallets-length').textContent || '0')).toBeGreaterThanOrEqual(0);
+  });
+
+  test('resetWeb3AuthClients can be called without errors', async () => {
+    let resetFunction: (() => Promise<void>) | undefined;
+
+    const TestComponent = () => {
+      const context = React.useContext(Web3AuthContext);
+      resetFunction = context.resetWeb3AuthClients;
+      return <div>test</div>;
+    };
+
+    render(
+      <Web3AuthProvider>
+        <TestComponent />
+      </Web3AuthProvider>
+    );
+
+    expect(resetFunction).toBeDefined();
+    if (resetFunction) {
+      // Should not throw
+      await expect(resetFunction()).resolves.toBeUndefined();
+    }
+  });
+
+  test('isSigning state management works correctly', () => {
+    let setSigningFunction: ((isSigning: boolean) => void) | undefined;
+    let isSigningValue: boolean | undefined;
+
+    const TestComponent = () => {
+      const context = React.useContext(Web3AuthContext);
+      setSigningFunction = context.setIsSigning;
+      isSigningValue = context.isSigning;
+      return (
+        <div>
+          <span data-testid="signing-state">{context.isSigning.toString()}</span>
+        </div>
+      );
+    };
+
+    const { getByTestId, rerender } = render(
+      <Web3AuthProvider>
+        <TestComponent />
+      </Web3AuthProvider>
+    );
+
+    // Initial state should be false
+    expect(getByTestId('signing-state').textContent).toBe('false');
+
+    // Set signing to true
+    if (setSigningFunction) {
+      setSigningFunction(true);
+      rerender(
+        <Web3AuthProvider>
+          <TestComponent />
+        </Web3AuthProvider>
+      );
+      expect(getByTestId('signing-state').textContent).toBe('true');
+
+      // Set signing back to false
+      setSigningFunction(false);
+      rerender(
+        <Web3AuthProvider>
+          <TestComponent />
+        </Web3AuthProvider>
+      );
+      expect(getByTestId('signing-state').textContent).toBe('false');
+    }
+  });
+
+  test('promptId state management works correctly', () => {
+    let setPromptIdFunction: ((promptId: string | undefined) => void) | undefined;
+
+    const TestComponent = () => {
+      const context = React.useContext(Web3AuthContext);
+      setPromptIdFunction = context.setPromptId;
+      return (
+        <div>
+          <span data-testid="prompt-id">{context.promptId || 'undefined'}</span>
+        </div>
+      );
+    };
+
+    const { getByTestId, rerender } = render(
+      <Web3AuthProvider>
+        <TestComponent />
+      </Web3AuthProvider>
+    );
+
+    // Initial state should be undefined
+    expect(getByTestId('prompt-id').textContent).toBe('undefined');
+
+    // Set prompt ID
+    if (setPromptIdFunction) {
+      setPromptIdFunction('test-prompt');
+      rerender(
+        <Web3AuthProvider>
+          <TestComponent />
+        </Web3AuthProvider>
+      );
+      expect(getByTestId('prompt-id').textContent).toBe('test-prompt');
+
+      // Clear prompt ID
+      setPromptIdFunction(undefined);
+      rerender(
+        <Web3AuthProvider>
+          <TestComponent />
+        </Web3AuthProvider>
+      );
+      expect(getByTestId('prompt-id').textContent).toBe('undefined');
+    }
+  });
+});

--- a/contexts/web3AuthContext.tsx
+++ b/contexts/web3AuthContext.tsx
@@ -1,9 +1,14 @@
 import { MainWalletBase } from '@cosmos-kit/core';
 import { wallets as cosmosExtensionWallets } from '@cosmos-kit/cosmos-extension-metamask';
-import { SignData, Web3AuthWallet, makeWeb3AuthWallets } from '@cosmos-kit/web3auth';
+import {
+  SignData,
+  Web3AuthClient,
+  Web3AuthWallet,
+  makeWeb3AuthWallets,
+} from '@cosmos-kit/web3auth';
 import { WEB3AUTH_NETWORK_TYPE } from '@web3auth/auth';
 import { wallets as cosmosWallets } from 'cosmos-kit';
-import { ReactNode, createContext, useMemo, useState } from 'react';
+import { ReactNode, createContext, useCallback, useMemo, useState } from 'react';
 
 import env from '@/config/env';
 
@@ -17,6 +22,8 @@ export interface Web3AuthContextType {
   wallets: (MainWalletBase | Web3AuthWallet)[];
   isSigning: boolean;
   setIsSigning: (isSigning: boolean) => void;
+  resetWeb3AuthClients: () => Promise<void>;
+  forceChainProviderReset?: () => void;
 }
 
 export const Web3AuthContext = createContext<Web3AuthContextType>({
@@ -26,6 +33,8 @@ export const Web3AuthContext = createContext<Web3AuthContextType>({
   wallets: [],
   isSigning: false,
   setIsSigning: () => {},
+  resetWeb3AuthClients: async () => {},
+  forceChainProviderReset: undefined,
 });
 
 export const Web3AuthProvider = ({ children }: { children: ReactNode }) => {
@@ -127,6 +136,39 @@ export const Web3AuthProvider = ({ children }: { children: ReactNode }) => {
     []
   );
 
+  /**
+   * Reset Web3Auth clients and force cosmos-kit to refresh its client cache.
+   * This is essential when switching between social accounts to prevent stale client state.
+   */
+  const resetWeb3AuthClients = useCallback(async () => {
+    try {
+      // Clear Web3Auth login hints for all social wallets
+      web3AuthWallets.forEach(wallet => {
+        if (wallet instanceof Web3AuthWallet && wallet.client instanceof Web3AuthClient) {
+          // Clear any stored login hints using the available method
+          wallet.client.setLoginHint('');
+        }
+      });
+
+      // Force disconnect all Web3Auth wallets to clear their cached state
+      const disconnectPromises = web3AuthWallets.map(async wallet => {
+        if (wallet instanceof Web3AuthWallet) {
+          try {
+            if (wallet.walletStatus === 'Connected') {
+              await wallet.disconnect();
+            }
+          } catch (error) {
+            console.warn(`Failed to disconnect wallet ${wallet.walletInfo.name}:`, error);
+          }
+        }
+      });
+
+      await Promise.all(disconnectPromises);
+    } catch (error) {
+      console.error('❌ Error resetting Web3Auth clients:', error);
+    }
+  }, [web3AuthWallets]);
+
   // Combine the Web3auth wallets with the other wallets
   const wallets = [
     ...web3AuthWallets,
@@ -136,7 +178,15 @@ export const Web3AuthProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <Web3AuthContext.Provider
-      value={{ prompt, promptId, setPromptId, wallets, isSigning, setIsSigning }}
+      value={{
+        prompt,
+        promptId,
+        setPromptId,
+        wallets,
+        isSigning,
+        setIsSigning,
+        resetWeb3AuthClients,
+      }}
     >
       {children}
     </Web3AuthContext.Provider>

--- a/hooks/__tests__/useClientReset.test.tsx
+++ b/hooks/__tests__/useClientReset.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, jest, test } from 'bun:test';
+import React from 'react';
+
+import { Web3AuthContext } from '@/contexts/web3AuthContext';
+import { clearAllMocks, mockModule } from '@/tests';
+
+import { useClientReset } from '../useClientReset';
+
+describe('useClientReset', () => {
+  let mockResetWeb3AuthClients: any;
+  let mockForceChainProviderReset: any;
+  let mockWeb3AuthContextValue: any;
+  let mockQueryClient: any;
+
+  beforeEach(() => {
+    mockResetWeb3AuthClients = jest.fn().mockResolvedValue(undefined);
+    mockForceChainProviderReset = jest.fn();
+
+    mockWeb3AuthContextValue = {
+      resetWeb3AuthClients: mockResetWeb3AuthClients,
+      forceChainProviderReset: mockForceChainProviderReset,
+      isSigning: false,
+      setIsSigning: jest.fn(),
+      setPromptId: jest.fn(),
+    };
+
+    mockQueryClient = {
+      clear: jest.fn(),
+    };
+
+    // Mock react-query
+    mockModule('@tanstack/react-query', () => ({
+      useQueryClient: () => mockQueryClient,
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearAllMocks();
+    jest.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Web3AuthContext.Provider value={mockWeb3AuthContextValue}>{children}</Web3AuthContext.Provider>
+  );
+
+  test('returns forceCompleteReset function', () => {
+    const { result } = renderHook(() => useClientReset(), { wrapper });
+
+    expect(result.current.forceCompleteReset).toBeDefined();
+    expect(typeof result.current.forceCompleteReset).toBe('function');
+  });
+
+  test('forceCompleteReset performs complete reset when forceChainProviderReset is available', async () => {
+    const { result } = renderHook(() => useClientReset(), { wrapper });
+
+    const resetResult = await result.current.forceCompleteReset();
+
+    expect(resetResult).toBe(true);
+    expect(mockResetWeb3AuthClients).toHaveBeenCalledTimes(1);
+    expect(mockForceChainProviderReset).toHaveBeenCalledTimes(1);
+    expect(mockQueryClient.clear).toHaveBeenCalledTimes(1);
+  });
+
+  test('forceCompleteReset returns false when forceChainProviderReset is not available', async () => {
+    mockWeb3AuthContextValue.forceChainProviderReset = undefined;
+
+    const { result } = renderHook(() => useClientReset(), { wrapper });
+
+    const resetResult = await result.current.forceCompleteReset();
+
+    expect(resetResult).toBe(false);
+    expect(mockResetWeb3AuthClients).not.toHaveBeenCalled();
+    expect(mockQueryClient.clear).not.toHaveBeenCalled();
+  });
+
+  test('forceCompleteReset handles reset errors gracefully', async () => {
+    mockResetWeb3AuthClients.mockRejectedValueOnce(new Error('Reset failed'));
+
+    const { result } = renderHook(() => useClientReset(), { wrapper });
+
+    await expect(result.current.forceCompleteReset()).rejects.toThrow('Reset failed');
+
+    expect(mockResetWeb3AuthClients).toHaveBeenCalledTimes(1);
+  });
+
+  test('callback is memoized correctly', () => {
+    const { result, rerender } = renderHook(() => useClientReset(), { wrapper });
+
+    const firstCallback = result.current.forceCompleteReset;
+
+    rerender();
+
+    const secondCallback = result.current.forceCompleteReset;
+
+    expect(firstCallback).toBe(secondCallback);
+  });
+});

--- a/hooks/useClientReset.ts
+++ b/hooks/useClientReset.ts
@@ -1,0 +1,34 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useContext } from 'react';
+
+import { Web3AuthContext } from '@/contexts/web3AuthContext';
+
+/**
+ * Hook to force complete reset of cosmos-kit and Web3Auth clients.
+ * This completely re-mounts the ChainProvider to clear all cached state.
+ */
+export const useClientReset = () => {
+  const { resetWeb3AuthClients, forceChainProviderReset } = useContext(Web3AuthContext);
+  const queryClient = useQueryClient();
+
+  const forceCompleteReset = useCallback(async () => {
+    if (forceChainProviderReset) {
+      // Reset Web3Auth state
+      await resetWeb3AuthClients();
+
+      // Clear all caches
+      queryClient.clear();
+
+      // Force complete re-mount
+      forceChainProviderReset();
+
+      return true;
+    } else {
+      return false;
+    }
+  }, [forceChainProviderReset, resetWeb3AuthClients, queryClient]);
+
+  return {
+    forceCompleteReset,
+  };
+};

--- a/tests/format.ts
+++ b/tests/format.ts
@@ -1,7 +1,7 @@
 import { format as prettyFormat, plugins as prettyFormatPlugins } from 'pretty-format';
 
 export function formatComponent(value: any): string {
-  return prettyFormat(value, {
+  const formatted = prettyFormat(value, {
     escapeRegex: true,
     indent: 2,
     plugins: [
@@ -14,4 +14,14 @@ export function formatComponent(value: any): string {
     ],
     printFunctionName: false,
   });
+
+  // Normalize dynamic Headless UI IDs for consistent snapshots
+  return formatted
+    .replace(/headlessui-dialog-«r\w+»/g, 'headlessui-dialog-«normalized»')
+    .replace(/headlessui-dialog-panel-«r\w+»/g, 'headlessui-dialog-panel-«normalized»')
+    .replace(/headlessui-\w+-«r\w+»/g, match => {
+      // Handle other headless UI components like headlessui-menu-«rXX», etc.
+      const componentType = match.split('-')[1];
+      return `headlessui-${componentType}-«normalized»`;
+    });
 }

--- a/tests/format.ts
+++ b/tests/format.ts
@@ -16,12 +16,5 @@ export function formatComponent(value: any): string {
   });
 
   // Normalize dynamic Headless UI IDs for consistent snapshots
-  return formatted
-    .replace(/headlessui-dialog-«r\w+»/g, 'headlessui-dialog-«normalized»')
-    .replace(/headlessui-dialog-panel-«r\w+»/g, 'headlessui-dialog-panel-«normalized»')
-    .replace(/headlessui-\w+-«r\w+»/g, match => {
-      // Handle other headless UI components like headlessui-menu-«rXX», etc.
-      const componentType = match.split('-')[1];
-      return `headlessui-${componentType}-«normalized»`;
-    });
+  return formatted.replace(/headlessui-([\w-]+)-«r\w+»/g, 'headlessui-$1-«normalized»');
 }


### PR DESCRIPTION
fixes #450 

The issue was that the wallet was caching stale data in the ChainProvider for web3auth wallets

This PR does not meet the target coverage because it does not contain tests for the useTx hook but #466 does. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a reset function to fully clear and reinitialize wallet and chain provider state, accessible from relevant modals and components.

- **Bug Fixes**
  - Improved transaction simulation error messages for greater clarity and support for more error types.
  - Enhanced handling of wallet address switching during transaction signing to reduce potential issues.

- **Chores**
  - Updated internal hooks and context to support comprehensive client and state resets.
  - Added tests for client reset functionality, web3 authentication context, and modal component behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->