### PR TITLE
ci: remove axelar from ci

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,11 +45,6 @@ jobs:
           echo "NEXT_PUBLIC_OSMOSIS_RPC_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_RPC_URL }}" >> .env
           echo "NEXT_PUBLIC_OSMOSIS_API_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_API_URL }}" >> .env
           echo "NEXT_PUBLIC_OSMOSIS_EXPLORER_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_EXPLORER_URL }}" >> .env
-          echo "NEXT_PUBLIC_AXELAR_CHAIN=${{ vars.NEXT_PUBLIC_AXELAR_CHAIN }}" >> .env
-          echo "NEXT_PUBLIC_AXELAR_CHAIN_ID=${{ vars.NEXT_PUBLIC_AXELAR_CHAIN_ID }}" >> .env
-          echo "NEXT_PUBLIC_AXELAR_RPC_URL=${{ vars.NEXT_PUBLIC_AXELAR_RPC_URL }}" >> .env
-          echo "NEXT_PUBLIC_AXELAR_API_URL=${{ vars.NEXT_PUBLIC_AXELAR_API_URL }}" >> .env
-          echo "NEXT_PUBLIC_AXELAR_EXPLORER_URL=${{ vars.NEXT_PUBLIC_AXELAR_EXPLORER_URL }}" >> .env
           echo "NEXT_PUBLIC_LEAP_DEEPLINK=${{ vars.NEXT_PUBLIC_LEAP_DEEPLINK }}" >> .env
           cat .env
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docker.yml` file. The change removes environment variable definitions related to Axelar (`NEXT_PUBLIC_AXELAR_CHAIN`, `NEXT_PUBLIC_AXELAR_CHAIN_ID`, `NEXT_PUBLIC_AXELAR_RPC_URL`, `NEXT_PUBLIC_AXELAR_API_URL`, and `NEXT_PUBLIC_AXELAR_EXPLORER_URL`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed environment variables related to the "AXELAR" chain from the Docker build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->