### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: Build and Push Docker Image
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/liftedinit/manifest-app/security/code-scanning/5](https://github.com/liftedinit/manifest-app/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. In this case, the workflow only needs to check out code and does not interact with the repository in a write capacity, so `contents: read` is sufficient. The best place to add this is at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No other changes are needed.

**Steps:**
- Edit `.github/workflows/docker.yml`.
- Insert the following block after the `name:` line and before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No imports, methods, or other definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
