### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,4 +1,6 @@
 name: Prettier
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/liftedinit/manifest-app/security/code-scanning/4](https://github.com/liftedinit/manifest-app/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks code formatting and does not push changes or interact with issues or pull requests, it only needs `contents: read` permission. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions. The change should be made at the top of `.github/workflows/prettier.yml`, after the `name` and before `on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
