### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,4 +1,6 @@
 name: Test and Coverage
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/liftedinit/manifest-app/security/code-scanning/3](https://github.com/liftedinit/manifest-app/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the least privilege required. In this case, the workflow appears to only need to read repository contents and upload coverage to Codecov (which uses its own token). Therefore, setting `permissions: contents: read` at the workflow level is sufficient and safest. This should be added near the top of the file, after the `name` and before `on`. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
