### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/liftedinit/manifest-app/security/code-scanning/2](https://github.com/liftedinit/manifest-app/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code and runs build steps, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This block can be added either at the workflow root (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add it at the workflow root, just below the `name` and before the `on` key, to ensure all jobs inherit the least privilege unless otherwise specified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
