### PR TITLE
fix: use bun runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ ENV PORT=3000
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
 ENV HOSTNAME="0.0.0.0"
-CMD ["node", "server.js"]
+CMD ["bun", "server.js"]


### PR DESCRIPTION
This pull request updates the application startup command in the `Dockerfile` to use the Bun runtime instead of Node.js for running `server.js`.

- Docker runtime update:
  * Changed the `CMD` instruction in the `Dockerfile` to use `bun` instead of `node` for starting the server, which may improve performance or compatibility with Bun features.