### PR TITLE
chore: typo

### DIFF
--- a/components/admins/components/validatorList.tsx
+++ b/components/admins/components/validatorList.tsx
@@ -40,7 +40,7 @@ export default function ValidatorList({
 
   const isActiveTab = activeTab === 0;
   const isPendingTab = activeTab === 1;
-  const isUnboundingTab = activeTab === 2;
+  const isUnbondingTab = activeTab === 2;
 
   const hasUnbondingValidators = useMemo(() => {
     return Array.isArray(unbondingValidators) && unbondingValidators.length > 0;
@@ -129,7 +129,7 @@ export default function ValidatorList({
                        disabled:text-[#404040] disabled:cursor-not-allowed
                        focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0"
           >
-            Unbounding
+            Unbonding
           </Tab>
         </Tab.List>
       </Tab.Group>
@@ -216,7 +216,7 @@ export default function ValidatorList({
                                 className="btn btn-error btn-sm text-white"
                                 data-testid="remove-validator"
                                 aria-label={`Remove validator ${validator.description.moniker}`}
-                                disabled={isUnboundingTab}
+                                disabled={isUnbondingTab}
                               >
                                 <TrashIcon className="w-5 h-5" />
                               </button>
@@ -241,7 +241,7 @@ export default function ValidatorList({
         validatorVPArray={validatorVPArray}
         openValidatorModal={openValidatorModal}
         setOpenValidatorModal={setOpenValidatorModal}
-        hasUnbounding={hasUnbondingValidators}
+        hasUnbonding={hasUnbondingValidators}
       />
       <WarningModal
         admin={admin}

--- a/components/admins/modals/__tests__/validatorModal.test.tsx
+++ b/components/admins/modals/__tests__/validatorModal.test.tsx
@@ -3,12 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import React from 'react';
 
 import { ValidatorDetailsModal } from '@/components/admins/modals/validatorModal';
-import {
-  clearAllMocks,
-  mockPendingValidators,
-  mockRouter,
-  mockUnboundingValidators,
-} from '@/tests';
+import { clearAllMocks, mockPendingValidators, mockRouter, mockUnbondingValidators } from '@/tests';
 import { mockActiveValidators } from '@/tests/data';
 import { renderWithChainProvider } from '@/tests/render';
 
@@ -26,7 +21,7 @@ function renderWithProps(props = {}) {
       admin={admin}
       totalvp={totalvp}
       validatorVPArray={validatorVPArray}
-      hasUnbounding={false}
+      hasUnbonding={false}
       {...props}
     />
   );
@@ -105,8 +100,8 @@ describe('ValidatorDetailsModal Component', () => {
     });
   });
 
-  test('show banner when hasUnbounding is true (active)', () => {
-    renderWithProps({ hasUnbounding: true });
+  test('show banner when hasUnbonding is true (active)', () => {
+    renderWithProps({ hasUnbonding: true });
 
     expect(
       screen.queryByText(/You cannot update validator power while validator\(s\) are unbonding\./i)
@@ -116,8 +111,8 @@ describe('ValidatorDetailsModal Component', () => {
     expect(updateButton).toBeDisabled();
   });
 
-  test('show banner when hasUnbounding is true (pending)', () => {
-    renderWithProps({ validator: mockPendingValidators[0], hasUnbounding: true });
+  test('show banner when hasUnbonding is true (pending)', () => {
+    renderWithProps({ validator: mockPendingValidators[0], hasUnbonding: true });
 
     expect(
       screen.queryByText(/You cannot update validator power while validator\(s\) are unbonding\./i)
@@ -128,7 +123,7 @@ describe('ValidatorDetailsModal Component', () => {
   });
 
   test('shows UNBONDING TIME and hides POWER when unbonding_time is set', () => {
-    renderWithProps({ validator: mockUnboundingValidators[0], hasUnbounding: true });
+    renderWithProps({ validator: mockUnbondingValidators[0], hasUnbonding: true });
 
     expect(screen.getByText('UNBONDING TIME (UTC)')).toBeInTheDocument();
     expect(screen.queryByText('POWER')).not.toBeInTheDocument();

--- a/components/admins/modals/validatorModal.tsx
+++ b/components/admins/modals/validatorModal.tsx
@@ -33,7 +33,7 @@ export function ValidatorDetailsModal({
   validatorVPArray,
   openValidatorModal,
   setOpenValidatorModal,
-  hasUnbounding,
+  hasUnbonding,
 }: Readonly<{
   validator: ExtendedValidatorSDKType | null;
   admin: string;
@@ -41,7 +41,7 @@ export function ValidatorDetailsModal({
   validatorVPArray: { vp: bigint; moniker: string }[];
   openValidatorModal: boolean;
   setOpenValidatorModal: (open: boolean) => void;
-  hasUnbounding: boolean;
+  hasUnbonding: boolean;
 }>) {
   const [description, setDescription] = useState<string | undefined>(undefined);
 
@@ -199,7 +199,7 @@ export function ValidatorDetailsModal({
                         <button
                           type="submit"
                           className="btn btn-gradient w-1/3"
-                          disabled={!isValid || isSigning || hasUnbounding}
+                          disabled={!isValid || isSigning || hasUnbonding}
                           onClick={() => {
                             handleUpdate({ power: power });
                           }}
@@ -211,7 +211,7 @@ export function ValidatorDetailsModal({
                           )}
                         </button>
                       </div>
-                      {hasUnbounding && (
+                      {hasUnbonding && (
                         <div className="alert alert-warning mt-2" role="alert" aria-live="polite">
                           <span>
                             You cannot update validator power while validator(s) are unbonding.

--- a/tests/data.ts
+++ b/tests/data.ts
@@ -166,7 +166,7 @@ export const mockPendingValidators: ExtendedValidatorSDKType[] = [
   },
 ];
 
-export const mockUnboundingValidators: ExtendedValidatorSDKType[] = [
+export const mockUnbondingValidators: ExtendedValidatorSDKType[] = [
   {
     operator_address: 'validator4',
     description: {


### PR DESCRIPTION
This pull request standardizes the terminology from "unbounding" to "unbonding" across the codebase for validator-related components and tests. This improves clarity and consistency in both the UI and internal logic.

Terminology updates:

* Renamed all instances of `isUnboundingTab`, `hasUnbounding`, and `mockUnboundingValidators` to `isUnbondingTab`, `hasUnbonding`, and `mockUnbondingValidators` respectively in `validatorList.tsx`, `validatorModal.tsx`, and related test files. [[1]](diffhunk://#diff-42ee9e0d6da951901133e4324eb2ddfc65a682b246e8b04281eb276b34457b25L43-R43) [[2]](diffhunk://#diff-42ee9e0d6da951901133e4324eb2ddfc65a682b246e8b04281eb276b34457b25L244-R244) [[3]](diffhunk://#diff-6f89d319aef0a5680d64b40db32d8a4d691b98a236f344e5fc6237d52371cb7bL36-R44) [[4]](diffhunk://#diff-6f89d319aef0a5680d64b40db32d8a4d691b98a236f344e5fc6237d52371cb7bL202-R202) [[5]](diffhunk://#diff-6f89d319aef0a5680d64b40db32d8a4d691b98a236f344e5fc6237d52371cb7bL214-R214) [[6]](diffhunk://#diff-82016d8d83e7774c722a181f39ff8807a8cab4ce3f950ae3eda91237a4e36898L6-R6) [[7]](diffhunk://#diff-82016d8d83e7774c722a181f39ff8807a8cab4ce3f950ae3eda91237a4e36898L29-R24) [[8]](diffhunk://#diff-82016d8d83e7774c722a181f39ff8807a8cab4ce3f950ae3eda91237a4e36898L108-R104) [[9]](diffhunk://#diff-82016d8d83e7774c722a181f39ff8807a8cab4ce3f950ae3eda91237a4e36898L119-R115) [[10]](diffhunk://#diff-82016d8d83e7774c722a181f39ff8807a8cab4ce3f950ae3eda91237a4e36898L131-R126) [[11]](diffhunk://#diff-af8bb1d99ad77e2026fb68ba4d41ea45cb6ce9ed18da7be6942145afc83e2176L169-R169)

UI consistency:

* Updated the tab label from "Unbounding" to "Unbonding" in the validator list UI.

Logic and behavior:

* Changed logic to disable actions and show warnings based on the new `isUnbondingTab` and `hasUnbonding` flags, ensuring correct behavior when validators are unbonding. [[1]](diffhunk://#diff-42ee9e0d6da951901133e4324eb2ddfc65a682b246e8b04281eb276b34457b25L219-R219) [[2]](diffhunk://#diff-6f89d319aef0a5680d64b40db32d8a4d691b98a236f344e5fc6237d52371cb7bL202-R202) [[3]](diffhunk://#diff-6f89d319aef0a5680d64b40db32d8a4d691b98a236f344e5fc6237d52371cb7bL214-R214)