### PR TITLE
ci: add new env var to .env

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,7 @@ jobs:
           echo "NEXT_PUBLIC_OSMOSIS_API_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_API_URL }}" >> .env
           echo "NEXT_PUBLIC_OSMOSIS_EXPLORER_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_EXPLORER_URL }}" >> .env
           echo "NEXT_PUBLIC_LEAP_DEEPLINK=${{ vars.NEXT_PUBLIC_LEAP_DEEPLINK }}" >> .env
+          echo "NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET=${{ vars.NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET }}" >> .env
           cat .env
 
       - name: Extract metadata (release tag)


### PR DESCRIPTION
This pull request adds a new environment variable to the Docker workflow configuration. The main change is the inclusion of `NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET` in the `.env` file, which ensures that this variable is available to the application during the build and deployment process.

Environment variable management:

* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94R66): Added a line to export `NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET` from GitHub Actions variables to the `.env` file, making it available for the application.